### PR TITLE
More workflow content, plus workflow cheat sheet

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -74,7 +74,7 @@ entries:
     - title: Enabling Features
       url: /toggle-features.html
       output: web
-      
+
       subfolders:
       - title: Coding Best Practices
         output: web
@@ -208,9 +208,18 @@ entries:
       url: /access-controls.html
       output: web
 
-    - title: Workflow and Mediated Deposit
-      url: /workflow_and_mediated_deposit.html
-      output: web
+      subfolders:
+      - title: Workflow and Mediated Deposit
+        output: web
+        subfolderitems:
+
+        - title: Workflow and Mediated Deposit Overview
+          url: /workflow_and_mediated_deposit.html
+          output: web
+
+        - title: Workflow and Mediated Deposit Cheatsheet
+          url: /workflow_cheat_sheet.html
+          output: web
 
     - title: Working With Background Jobs
       url: /background-jobs.html

--- a/pages/hydra/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_and_mediated_deposit.md
+++ b/pages/hydra/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_and_mediated_deposit.md
@@ -107,6 +107,74 @@ w.setup
 ```
 Putting this code in `db/seeds.rb` means it will be called at the end of `bin/setup`, and you can call it anytime via `rake db:seed`
 
+## How do I test that all of this is working correctly?
+
+One approach is to make a capybara feature test for your approval workflow. You can log in
+as different users, and have those users perform workflow roles. Here is an example:
+```ruby
+# Check the ETD was assigned the right workflow
+etd = Etd.where(title: [title]).first
+expect(etd.active_workflow.name).to eq "emory_one_step_approval"
+expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "pending_approval"
+
+# Check workflow permissions for depositing user
+available_workflow_actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: user, entity: etd.to_sipity_entity).pluck(:name)
+expect(available_workflow_actions.include?("mark_as_reviewed")).to eq false
+expect(available_workflow_actions.include?("approve")).to eq false
+expect(available_workflow_actions.include?("request_changes")).to eq false
+expect(available_workflow_actions.include?("comment_only")).to eq false
+expect(available_workflow_actions.include?("hide")).to eq false
+expect(available_workflow_actions.include?("unhide")).to eq false
+
+# Check notifications for depositing user
+visit("/notifications?locale=en")
+expect(page).to have_content "#{title} (#{etd.id}) was deposited by #{user.email} and is awaiting approval."
+
+# Check notifications for approving user
+logout
+approving_user = User.where(email: "candleradmin@emory.edu").first
+login_as approving_user
+visit("/notifications?locale=en")
+expect(page).to have_content "#{title} (#{etd.id}) was deposited by #{user.email} and is awaiting approval."
+
+# Check workflow permissions for approving user
+available_workflow_actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: approving_user, entity: etd.to_sipity_entity).pluck(:name)
+expect(available_workflow_actions.include?("mark_as_reviewed")).to eq false # this workflow step should only exist for Laney
+expect(available_workflow_actions.include?("approve")).to eq true
+expect(available_workflow_actions.include?("request_changes")).to eq true
+expect(available_workflow_actions.include?("comment_only")).to eq true
+expect(available_workflow_actions.include?("hide")).to eq true
+expect(available_workflow_actions.include?("unhide")).to eq true
+
+# Last superuser should have all workflow options available. (First superuser gets these by virtue of owning the admin sets.)
+expect(w.superusers.count).to be > 1 # This test is meaningless if there is only one superuser
+available_workflow_actions = Hyrax::Workflow::PermissionQuery.scope_permitted_workflow_actions_available_for_current_state(user: w.superusers.last, entity: etd.to_sipity_entity).pluck(:name)
+expect(available_workflow_actions.include?("mark_as_reviewed")).to eq false # this workflow step should only exist for Laney
+expect(available_workflow_actions.include?("approve")).to eq true
+expect(available_workflow_actions.include?("request_changes")).to eq true
+expect(available_workflow_actions.include?("comment_only")).to eq true
+expect(available_workflow_actions.include?("hide")).to eq true
+expect(available_workflow_actions.include?("unhide")).to eq true
+
+# The approving user marks the etd as approved
+subject = Hyrax::WorkflowActionInfo.new(etd, approving_user)
+sipity_workflow_action = PowerConverter.convert_to_sipity_action("approve", scope: subject.entity.workflow) { nil }
+Hyrax::Workflow::WorkflowActionService.run(subject: subject, action: sipity_workflow_action, comment: nil)
+expect(etd.to_sipity_entity.reload.workflow_state_name).to eq "approved"
+
+# Check notifications for approving user
+visit("/notifications?locale=en")
+expect(page).to have_content "Deposit #{title} has been approved"
+expect(page).to have_content "#{title} (#{etd.id}) has been approved by"
+
+# Check notifications for depositor again
+logout
+login_as user
+visit("/notifications?locale=en")
+expect(page).to have_content "Deposit #{title} has been approved"
+expect(page).to have_content "#{title} (#{etd.id}) has been approved by"
+```
+
 ## How do I set up an app to use a given workflow by default?
 
 coming soon...
@@ -114,7 +182,3 @@ coming soon...
 ## How do I diagram and configure a new workflow?
 
 coming soon ...
-
-## How do I test that all of this is working correctly?
-
-coming soon ... 

--- a/pages/hydra/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_cheat_sheet.md
+++ b/pages/hydra/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_cheat_sheet.md
@@ -1,0 +1,43 @@
+---
+title: "Workflow Cheat Sheet"
+keywords: Mediated Deposit, Workflow, Sipity
+categories: Workflow
+permalink: workflow_cheat_sheet.html
+folder: hydra/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_cheat_sheet.md
+sidebar: home_sidebar
+tags: [development_resources]
+---
+
+# Handy commands
+
+### Get the active workflow for a given admin set
+```ruby
+a = AdminSet.first
+workflow = a.active_workflow
+ => #<AdminSet id: "g732d8963", title: ["Laney Graduate School"], description: [], creator: ["redacted@fake.edu"], access_control_id: "ea6d2579-2f17-4e05-a348-f36716b783e5", representative_id: nil, thumbnail_id: nil>
+```
+
+### Get the workflow roles in a given workflow
+```ruby
+workflow_roles = workflow.workflow_roles
+=> #<ActiveRecord::Associations::CollectionProxy [#<Sipity::WorkflowRole id: 12, workflow_id: 3, role_id: 1, created_at: "2017-06-19 16:49:09", updated_at: "2017-06-19 16:49:09">, #<Sipity::WorkflowRole id: 6, workflow_id: 3, role_id: 2, created_at: "2017-06-19 16:49:09", updated_at: "2017-06-19 16:49:09">, #<Sipity::WorkflowRole id: 5, workflow_id: 3, role_id: 3, created_at: "2017-06-19 16:49:08", updated_at: "2017-06-19 16:49:08">, #<Sipity::WorkflowRole id: 4, workflow_id: 3, role_id: 4, created_at: "2017-06-19 16:49:08", updated_at: "2017-06-19 16:49:08">]>
+workflow_roles.map { |workflow_role| workflow_role.role.name }
+ => ["managing", "depositing", "reviewing", "approving"]
+```
+
+### Print out all the users and their roles for a given workflow (useful for debugging)
+```ruby
+workflow = AdminSet.where(title: ["Laney Graduate School"]).first.active_workflow
+User.all.each do |user|
+  puts "-----"
+  puts user.user_key
+  roles = Hyrax::Workflow::PermissionQuery.scope_processing_workflow_roles_for_user_and_workflow(user: user, workflow: workflow).pluck(:role_id)
+  puts roles.map { |r| Sipity::Role.where(id: r).first.name }
+end
+```
+
+### Get the workflow states in a given workflow
+```ruby
+workflow_states = workflow.workflow_states.pluck(:name)
+ => ["approved", "changes_required", "pending_approval", "pending_review"]
+```


### PR DESCRIPTION
Adding workflow cheatsheet
Adding testing example
Adding workflow to sidebar menu as a folder
- [x] Get @jeremyf 's thoughts on whether `scope_processing_workflow_roles_for_user_and_workflow` should be public or private
- [ ] Add `<ul class='info'><li>These instructions apply to Hyrax 1.0.  The instructions are likely similar for later releases.  The links in this document go to the <a href='https://github.com/samvera/hyrax/tree/1-0-stable'>1-0-stable</a> branch.</li></ul>` to page header