### PR TITLE
Add a-z indexing page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,6 @@ source "https://rubygems.org"
 
 # gem 'documentation-theme-jekyll', github: 'elrayle/documentation-theme-jekyll', branch: 'gh-pages'
 
-gem 'github-pages', group: :jekyll_plugins
+# gem 'github-pages', group: :jekyll_plugins
+gem 'github-pages' # plugins will not run if group: :jekyll_plugins is used
+

--- a/README.md
+++ b/README.md
@@ -9,8 +9,44 @@ These are community documents, so we rely on the pull request model. If you'd li
 - clone the project
 - make a branch  
 - create/edit pages within the Hydra directory
-- add their links to home_sidebar.yml
-- tag them appropriately
+- add/update [front matter](#basic-front-matter)
+- add links to the page in home_sidebar.yml
+- [generate the A-Z Index](#generate-the-a-z-index-page), if needed
+- submit a Pull Request
+
+### Basic Front Matter
+
+Example front matter for page [Best Practices -> Coding Styles](https://raw.githubusercontent.com/samvera/samvera.github.io/master/pages/hydra/developer_resources/best_practices/coding_style.md)
+```
+---
+title: "Coding Style with RuboCop"
+permalink: best-practices-coding-styles.html
+folder: hydra/how-to/best_practices/coding_styles.md
+sidebar: home_sidebar
+a-z: ['Coding Styles', 'Rubocop']
+keywords: Best Practices
+tags: [development_resources]
+categories: How to Do All the Things
+---
+```
+where,
+* **title** [String] - _(required)__ - the title displayed on the generated html page
+* **permalink** [text] - _(required)_ - the name of the generated html file that will be part of the url accessed by users
+* **folder** [text] - _(required)_ - the location of this *.md file under the pages directory
+* **sidebar** [text] - _(required)_ - value is always `homr_sidebar` at this point
+* **a-z** [Array<Strings>] - _(recommended)_ - array of terms to link to this page in the A-Z Index
+* **keywords** [comma separated list] - _(recommended)_ - keywords that get populated into the metadata of the page for SEO
+* **tags** [Array<text>] - _(recommended)_ - array of tags where tags must be defined in your [_data/tags.yml](https://github.com/samvera/samvera.github.io/tree/master/_data/tags.yml) list. You also need a corresponding tag file inside the [pages/tags](https://github.com/samvera/samvera.github.io/tree/master/pages/tags) folder that follows the same pattern as the other tag files shown in the tags folder.  It is rare that a new tag would be created.  If you think you need a new tag, be sure to highlight it as requiring review in the issue.
+* **categories** [text] - _(recommended)_ - ???
+
+
+### Generate the A-Z Index page
+
+```
+bundle exec jekyll build
+mv generated/atoz.md pages
+```
+Then commit pages/atoz.md to github
 
 
 ## Our Theme

--- a/_config.yml
+++ b/_config.yml
@@ -103,7 +103,20 @@ description: ""
 
 # needed for sitemap.xml file only
 url: http://samvera.github.io
-
 production_url : https://samvera.github.io
-
 BASE_PATH : https://samvera.github.io
+
+a_z:
+    index_title: false
+    filename: a-z.md
+    alternate_dest: '/generated'
+    exclude:
+      - '/atom.xml'
+      - '/feed.xml'
+      - '/feed/index.xml'
+      - '/generated/a-z.md'
+      - '/pages/a-z.md'
+      - '/pages/hydra/developer_resources/whwi-overview.md'
+    front_matter_ext:
+      - 'sidebar: home_sidebar'
+

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,0 +1,5 @@
+allowed-tags:
+  - getting_started
+  - development_resources
+  - running_in_production
+  - community

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -49,6 +49,9 @@
            </p>
            -->
     </li>
+    <li>
+      <a href="a-z.html">A-Z Index</a>
+    </li>
 </ul>
 </div>
 

--- a/_plugins/a_z_index_generator.rb
+++ b/_plugins/a_z_index_generator.rb
@@ -1,0 +1,277 @@
+# A-Z Index Generator is a Jekyll plugin that generates a a-z.md file by
+# traversing all of the available posts and pages adding an entry for each
+# a-z index tag in the front matter.
+#
+# See readme file for documenation
+#
+# Updated to use config file for settings by Daniel Groves
+# Site: http://danielgroves.net
+#
+# Author: Michael Levin
+# Site: http://www.kinnetica.com
+# Distributed Under A Creative Commons License
+#   - http://creativecommons.org/licenses/by/3.0/
+require 'jekyll/document'
+require 'rexml/document'
+
+module Jekyll
+  class Jekyll::Document
+    attr_accessor :name
+
+    def path_to_source
+      File.join(*[@name].compact)
+    end
+  end
+
+  class Page
+    attr_accessor :name
+
+    def path_to_source
+      File.join(*[@dir, @name].compact)
+    end
+  end
+
+  # Recover from strange exception when starting server without --auto
+  class AZIndexFile < StaticFile
+    def write(_dest)
+      true
+    end
+  end
+
+  class AZIndexGenerator < Generator
+    priority :lowest
+    safe true
+
+    # Config defaults
+    A_Z_FILE_NAME = '/a-z.html'.freeze
+    RELATIVE_PATH = ''.freeze
+    INDEX_TITLE = true
+    EXCLUDE = ['/atom.xml', '/feed.xml', '/feed/index.xml', '/a-z.html', '/a-z.md'].freeze
+    INCLUDE_POSTS = ['/index.html'].freeze
+    OUTPUT_TYPE = :html
+    FRONT_MATTER_EXT = [].freeze
+
+    # Goes through pages and posts and generates a-z.html file
+    #
+    # Returns nothing
+    def generate(site)
+      puts "Generating A-Z Index..."
+      process_config(site)
+
+      puts "   building the a-z index"
+      idx = initialize_index
+      # process_posts(site, idx)
+      process_pages(site, idx)
+      sort_index(idx)
+
+      puts "   writing to file: #{@config['filename']}"
+      write_index(site, idx)
+    end
+
+    def process_config(site)
+      a_z_config = site.config['a_z'] || {}
+      @config = {}
+      @config['filename'] = valid_filename(a_z_config['filename'])
+      @config['relative_path'] = a_z_config['relative_path'] || RELATIVE_PATH
+      @config['destination_path'] = valid_destination(site, a_z_config['alternate_dest'])
+      @config['output_type'] = determine_output_type
+      @config['index_title'] = valid_boolean(a_z_config['index_title'])
+      @config['exclude'] = a_z_config['exclude'] || EXCLUDE
+      # @config['include_posts'] = a_z_config['include_posts'] || INCLUDE_POSTS
+      @config['front_matter_ext'] = a_z_config['front_matter_ext'] || FRONT_MATTER_EXT
+    end
+
+    def initialize_index
+      { a: [], b: [], c: [], d: [], e: [], f: [], g: [], h: [], i: [], j: [], k: [], l: [], m: [], n: [], o: [], p: [], q: [], r: [], s: [], t: [], u: [], v: [], w: [], x: [], y: [], z: [] }
+    end
+
+    # # Create url elements for all the posts and find the date of the latest one
+    # #
+    # # Returns last_modified_date of latest post
+    # def process_posts(site, idx)
+    #   last_modified_date = nil
+    #   site.collections["posts"].docs.each do |post|
+    #     if !excluded?(post.name)
+    #       add_terms(site, idx, post)
+    #     end
+    #   end
+    # end
+
+    # Create url elements for all the normal pages and find the date of the
+    # index to use with the pagination pages
+    #
+    # Returns last_modified_date of index page
+    def process_pages(site, idx)
+      site.pages.each do |page|
+        unless excluded?(page.path_to_source)
+          add_terms(idx, page) if File.exist?(page.path)
+        end
+      end
+    end
+
+    # Add all a-z terms and title to the index.
+    def add_terms(idx, page_or_post)
+      url = page_url(page_or_post)
+      add_term(idx, page_or_post.data['title'], url) if index_title?
+      page_or_post.data['a-z'].each { |term| add_term(idx, term, url) } if page_or_post.data.key? 'a-z'
+    end
+
+    # Add a term to the index.
+    def add_term(idx, term, url)
+      return unless term.is_a? String
+      return unless url.is_a? String
+      idx[term[0].downcase.to_sym] << [term, url]
+    end
+
+    # Get URL location of page or post
+    #
+    # Returns the url of the page or post
+    def page_url(page_or_post)
+      "#{@config['relative_path']}#{page_or_post.url}"
+    end
+
+    # Sort index alphabetically and remove duplicate entries
+    def sort_index(idx)
+      idx.values.each do |section|
+        section.uniq!
+        section.sort! do |x, y|
+          if x[0] == y[0]
+            x[1] <=> y[1]
+          else
+            x[0] <=> y[0]
+          end
+        end
+      end
+    end
+
+    def write_index(site, idx)
+      file = File.new(File.join(@config['destination_path'], @config['filename']), "w")
+      # write_html(file, idx) if @config['output_type'] == :html
+      # write_md(file, idx) if @config['output_type'] == :md
+      write_md(file, idx)
+      file.close
+      site.static_files << Jekyll::AZIndexFile.new(site, site.dest, "/", @config['filename'])
+    end
+
+    def write_html(file, idx)
+      file.write "Hello World"
+      write_content(file, idx)
+    end
+
+    def write_md(file, idx)
+      file.puts "---"
+      file.puts "title: 'A-Z Index'"
+      file.puts "permalink: a-z.html"
+      file.puts "folder: a-z.md"
+      @config['front_matter_ext'].each { |fm| file.puts fm }
+      file.puts "---"
+      write_content(file, idx)
+    end
+
+    def write_content(file, idx)
+      file.puts "<div id='atoz'>"
+      write_toc(file)
+      write_terms(file, idx)
+      file.puts "</div>"
+    end
+
+    def write_toc(file)
+      file.puts "  <div class='atoz_tabs'>"
+      file.puts "    <a class='atoz_tab' href='#a'> A </a>"
+      file.puts "    <a class='atoz_tab' href='#b'> B </a>"
+      file.puts "    <a class='atoz_tab' href='#c'> C </a>"
+      file.puts "    <a class='atoz_tab' href='#d'> D </a>"
+      file.puts "    <a class='atoz_tab' href='#e'> E </a>"
+      file.puts "    <a class='atoz_tab' href='#f'> F </a>"
+      file.puts "    <a class='atoz_tab' href='#g'> G </a>"
+      file.puts "    <a class='atoz_tab' href='#h'> H </a>"
+      file.puts "    <a class='atoz_tab' href='#i'> I </a>"
+      file.puts "    <a class='atoz_tab' href='#j'> J </a>"
+      file.puts "    <a class='atoz_tab' href='#k'> K </a>"
+      file.puts "    <a class='atoz_tab' href='#l'> L </a>"
+      file.puts "    <a class='atoz_tab' href='#m'> M </a>"
+      file.puts "    <a class='atoz_tab' href='#n'> N </a>"
+      file.puts "    <a class='atoz_tab' href='#o'> O </a>"
+      file.puts "    <a class='atoz_tab' href='#p'> P </a>"
+      file.puts "    <a class='atoz_tab' href='#q'> Q </a>"
+      file.puts "    <a class='atoz_tab' href='#r'> R </a>"
+      file.puts "    <a class='atoz_tab' href='#s'> S </a>"
+      file.puts "    <a class='atoz_tab' href='#t'> T </a>"
+      file.puts "    <a class='atoz_tab' href='#u'> U </a>"
+      file.puts "    <a class='atoz_tab' href='#v'> V </a>"
+      file.puts "    <a class='atoz_tab' href='#w'> W </a>"
+      file.puts "    <a class='atoz_tab' href='#x'> X </a>"
+      file.puts "    <a class='atoz_tab' href='#y'> Y </a>"
+      file.puts "    <a class='atoz_tab' href='#z'> Z </a>"
+      file.puts "  </div>"
+    end
+
+    def write_terms(file, idx)
+      idx.each do |alpha, terms|
+        file.puts "  <div class='atoz_section'>"
+        file.puts "    <a class='atoz_anchor' name='#{alpha.to_s.downcase}'>&nbsp;</a>"
+        file.puts "    <span class='atoz_section_label'>#{alpha.to_s.upcase}</span>"
+
+        file.puts "    <div class='atoz_terms'>"
+        terms.each { |term_url| write_term(file, term_url) }
+        file.puts "    </div>"
+
+        file.puts "  </div>"
+      end
+    end
+
+    def write_term(file, term_url)
+      term = term_url[0]
+      url = term_url[1]
+      file.puts "      <a class='atoz_term' href='#{url}'>#{term}</a>"
+      file.puts "      <br>"
+    end
+
+    # Is the page or post listed as something we want to exclude?
+    #
+    # Returns boolean
+    def excluded?(name)
+      @config['exclude'].include? name
+    end
+
+    def posts_included?(name)
+      @config['include_posts'].include? name
+    end
+
+    def index_title?
+      @config['index_title']
+    end
+
+    def valid_filename(configured_value)
+      return A_Z_FILE_NAME unless configured_value
+      return A_Z_FILE_NAME unless configured_value.is_a? String
+      return A_Z_FILE_NAME if configured_value.empty?
+      configured_value
+    end
+
+    def determine_output_type
+      fn = @config['filename']
+      dot = fn.rindex('.')
+      ext = fn[dot + 1..fn.size] if dot && dot + 1 < fn.size
+      return OUTPUT_TYPE unless ext
+      return OUTPUT_TYPE if ext.empty?
+      return :html if ext.casecmp('html').zero?
+      return :md if ext.casecmp('md').zero?
+      OUTPUT_TYPE
+    end
+
+    def valid_boolean(configured_value)
+      return INDEX_TITLE unless configured_value
+      return configured_value if configured_value.is_a? TrueClass
+      return configured_value if configured_value.is_a? FalseClass
+      INDEX_TITLE
+    end
+
+    def valid_destination(site, configured_value)
+      path = site.dest
+      path = "#{site.source}/#{configured_value}" if configured_value.is_a? String
+      Dir.mkdir(path) unless Dir.exist?(path)
+      path
+    end
+  end
+end

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1202,3 +1202,105 @@ ul.warning {
     border-width: 2px;
     border-color: #ac1e26;
 }
+
+h4.version {
+
+}
+
+div#version_container {
+    display:inline-block;
+    padding-top: 3px;
+    padding-bottom: 20px;
+    border-top: solid 2px #17adec;
+    color: #696969;
+    font-size: 75%;
+    width: 100%;
+}
+
+div.version_label {
+    display:inline-block;
+    vertical-align: top;
+    width: 50%;
+    /*padding-bottom: 3px;*/
+    /*border-bottom: solid 2px #17adec;*/
+}
+
+div.version_selector {
+    display: inline-block;
+    vertical-align: top;
+    width: 48%;
+    text-align: right;
+}
+
+span.active_version {
+    font-weight: bold;
+    padding-left: 10px;
+    padding-right: 10px;
+    border-left: solid 1px #17adec;
+    border-right: solid 1px #17adec;
+    background-color: #f5f5b2;
+}
+
+a.alternate_version {
+    /*font-weight: bold;*/
+    padding-left: 10px;
+    padding-right: 10px;
+    border-left: solid 1px #17adec;
+    border-right: solid 1px #17adec;
+    /*background-color: lightcyan;*/
+}
+
+div#atoz {
+    /*font-weight: bold;*/
+    /*font-size: 12px;*/
+    /*font-family: "FontinSans500";*/
+}
+
+a.atoz_anchor {
+    display: block;
+    position: relative;
+    top: -50px;
+    visibility: hidden;
+}
+
+a.atoz_tab:link,
+a.atoz_tab:visited,
+a.atoz_tab:active {
+    color:#333;
+    text-decoration: underline;
+    font-weight: bold;
+    font-size: .8em;
+    padding-right: 10px;
+}
+a.atoz_tab:hover {
+    text-decoration:underline;
+    color: #a61700;
+    font-weight: bold;
+    font-size: .8em;
+}
+
+div.atoz_section {
+    padding-top: 10px;
+    padding-left: 10px;
+}
+
+span.atoz_section_label {
+    color: #a61700;
+    font-weight: bold;
+    font-size: 16px;
+}
+
+a.atoz_term:link,
+a.atoz_term:visited,
+a.atoz_term:active {
+    color:#333;
+    text-decoration: underline;
+    font-weight: bold;
+    font-size: 12px;
+}
+a.atoz_term:hover {
+    color: #a61700;
+    text-decoration:underline;
+    font-weight: bold;
+    font-size: 12px;
+}

--- a/pages/a-z.md
+++ b/pages/a-z.md
@@ -1,0 +1,356 @@
+---
+title: 'A-Z Index'
+permalink: a-z.html
+folder: a-z.md
+sidebar: home_sidebar
+---
+<div id='atoz'>
+  <div class='atoz_tabs'>
+    <a class='atoz_tab' href='#a'> A </a>
+    <a class='atoz_tab' href='#b'> B </a>
+    <a class='atoz_tab' href='#c'> C </a>
+    <a class='atoz_tab' href='#d'> D </a>
+    <a class='atoz_tab' href='#e'> E </a>
+    <a class='atoz_tab' href='#f'> F </a>
+    <a class='atoz_tab' href='#g'> G </a>
+    <a class='atoz_tab' href='#h'> H </a>
+    <a class='atoz_tab' href='#i'> I </a>
+    <a class='atoz_tab' href='#j'> J </a>
+    <a class='atoz_tab' href='#k'> K </a>
+    <a class='atoz_tab' href='#l'> L </a>
+    <a class='atoz_tab' href='#m'> M </a>
+    <a class='atoz_tab' href='#n'> N </a>
+    <a class='atoz_tab' href='#o'> O </a>
+    <a class='atoz_tab' href='#p'> P </a>
+    <a class='atoz_tab' href='#q'> Q </a>
+    <a class='atoz_tab' href='#r'> R </a>
+    <a class='atoz_tab' href='#s'> S </a>
+    <a class='atoz_tab' href='#t'> T </a>
+    <a class='atoz_tab' href='#u'> U </a>
+    <a class='atoz_tab' href='#v'> V </a>
+    <a class='atoz_tab' href='#w'> W </a>
+    <a class='atoz_tab' href='#x'> X </a>
+    <a class='atoz_tab' href='#y'> Y </a>
+    <a class='atoz_tab' href='#z'> Z </a>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='a'>&nbsp;</a>
+    <span class='atoz_section_label'>A</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/index.html'>A Guide For The Perplexed Hydra Developer</a>
+      <br>
+      <a class='atoz_term' href='/participants.html'>Admin Sets - Participants</a>
+      <br>
+      <a class='atoz_term' href='/how-to-admin-sets.html'>Admin Sets, Collections, Display Sets</a>
+      <br>
+      <a class='atoz_term' href='/what-are-admin-things.html'>Admin Sets: Key Terms</a>
+      <br>
+      <a class='atoz_term' href='/aws.html'>Amazon Web Services</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='b'>&nbsp;</a>
+    <span class='atoz_section_label'>B</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/background-jobs.html'>Background Jobs</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='c'>&nbsp;</a>
+    <span class='atoz_section_label'>C</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/code.html'>Code Guidelines</a>
+      <br>
+      <a class='atoz_term' href='/review.html'>Code Review</a>
+      <br>
+      <a class='atoz_term' href='/best-practices-coding-styles.html'>Coding Style with RuboCop</a>
+      <br>
+      <a class='atoz_term' href='/best-practices-coding-styles.html'>Coding Styles</a>
+      <br>
+      <a class='atoz_term' href='/communication.html'>Communication</a>
+      <br>
+      <a class='atoz_term' href='/customize-metadata-discovery.html'>Configuring Discovery</a>
+      <br>
+      <a class='atoz_term' href='/customize-metadata-controlled-vocabulary.html'>Controlled Vocabularies (Customizing Metadata)</a>
+      <br>
+      <a class='atoz_term' href='/admin-users.html'>Creating User Groups</a>
+      <br>
+      <a class='atoz_term' href='/groups.html'>Creating User Groups</a>
+      <br>
+      <a class='atoz_term' href='/customize-metadata-controlled-vocabulary.html'>Customizing Metadata (Controlled Vocabularies)</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='d'>&nbsp;</a>
+    <span class='atoz_section_label'>D</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/customize-metadata-model.html'>Defining Metadata in the Model</a>
+      <br>
+      <a class='atoz_term' href='/devops.html'>DevOps</a>
+      <br>
+      <a class='atoz_term' href='/tag_community.html'>Development Community</a>
+      <br>
+      <a class='atoz_term' href='/tag_development_resources.html'>Development Resources</a>
+      <br>
+      <a class='atoz_term' href='/deeper_hydra_index.html'>Dive Deeper into Hydra</a>
+      <br>
+      <a class='atoz_term' href='/training/deeper_into_hydra/'>Dive Deeper into Hydra</a>
+      <br>
+      <a class='atoz_term' href='/dive-deeper.html'>Dive Deeper into Hyrax</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='e'>&nbsp;</a>
+    <span class='atoz_section_label'>E</span>
+    <div class='atoz_terms'>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='f'>&nbsp;</a>
+    <span class='atoz_section_label'>F</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/formalities.html'>Formalities</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='g'>&nbsp;</a>
+    <span class='atoz_section_label'>G</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/getting_started.html'>Get up and running</a>
+      <br>
+      <a class='atoz_term' href='/tag_getting_started.html'>Getting started pages</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='h'>&nbsp;</a>
+    <span class='atoz_section_label'>H</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/hardware-considerations.html'>Hardware Considerations</a>
+      <br>
+      <a class='atoz_term' href='/high-level.html'>High-level Introduction to the Project</a>
+      <br>
+      <a class='atoz_term' href='/add-new-work-type.html'>How Do I Add a New Work Type?</a>
+      <br>
+      <a class='atoz_term' href='/building-searches.html'>How Do I Build Searches?</a>
+      <br>
+      <a class='atoz_term' href='/plugins.html'>How Do I Make a Hyrax Plugin?</a>
+      <br>
+      <a class='atoz_term' href='/get-help.html'>How to Ask for Help</a>
+      <br>
+      <a class='atoz_term' href='/toggle-features.html'>How to Enable and Disable Features</a>
+      <br>
+      <a class='atoz_term' href='/extend-hyrax.html'>How to Extend Hyrax</a>
+      <br>
+      <a class='atoz_term' href='/hyrax-out-of-the-box.html'>How to Hyrax: Out of the Box </a>
+      <br>
+      <a class='atoz_term' href='/install-hyrax.html'>How to Install Hyrax</a>
+      <br>
+      <a class='atoz_term' href='/how-to-pr.html'>How to Submit Pull Requests</a>
+      <br>
+      <a class='atoz_term' href='/hyku-vs-hyrax.html'>Hyku vs Hyrax?</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='i'>&nbsp;</a>
+    <span class='atoz_section_label'>I</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/campus-auth-integrating.html'>Integrating with Campus Authorization</a>
+      <br>
+      <a class='atoz_term' href='/real-life-hyrax.html'>Interest Groups, Working Groups, Conferences</a>
+      <br>
+      <a class='atoz_term' href='/introduction.html'>Introduction</a>
+      <br>
+      <a class='atoz_term' href='/issues.html'>Issues</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='j'>&nbsp;</a>
+    <span class='atoz_section_label'>J</span>
+    <div class='atoz_terms'>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='k'>&nbsp;</a>
+    <span class='atoz_section_label'>K</span>
+    <div class='atoz_terms'>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='l'>&nbsp;</a>
+    <span class='atoz_section_label'>L</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/customize-metadata-labels.html'>Labels and Help Text</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='m'>&nbsp;</a>
+    <span class='atoz_section_label'>M</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/customize-metadata-edit-form.html'>Modifying the Edit Form</a>
+      <br>
+      <a class='atoz_term' href='/customize-metadata-show-page.html'>Modifying the Show Page</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='n'>&nbsp;</a>
+    <span class='atoz_section_label'>N</span>
+    <div class='atoz_terms'>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='o'>&nbsp;</a>
+    <span class='atoz_section_label'>O</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/blacklight-plugins.html'>Other Blacklight Plugins</a>
+      <br>
+      <a class='atoz_term' href='/other-getting-started.html'>Other Helpful Getting Started Docs</a>
+      <br>
+      <a class='atoz_term' href='/customize-metadata-other-customizations.html'>Other Metadata Customizations</a>
+      <br>
+      <a class='atoz_term' href='/our_technology_stack.html'>Our Technology Stack</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='p'>&nbsp;</a>
+    <span class='atoz_section_label'>P</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/pcdm.html'>PCDM</a>
+      <br>
+      <a class='atoz_term' href='/best-practices-plugins.html'>Plugins</a>
+      <br>
+      <a class='atoz_term' href='/customize-metadata-controlled-vocabulary.html'>Prereq: Defining a Controlled Vocabulary</a>
+      <br>
+      <a class='atoz_term' href='/customize-metadata-generate-work-type.html'>Prereq: Generating a Work Type</a>
+      <br>
+      <a class='atoz_term' href='/test.html'>Project Hydra Training</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='q'>&nbsp;</a>
+    <span class='atoz_section_label'>Q</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/quality.html'>Quality Practices</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='r'>&nbsp;</a>
+    <span class='atoz_section_label'>R</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/hyrax-releases.html'>Releases</a>
+      <br>
+      <a class='atoz_term' href='/best-practices-coding-styles.html'>Rubocop</a>
+      <br>
+      <a class='atoz_term' href='/tag_running_in_production.html'>Running in Production</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='s'>&nbsp;</a>
+    <span class='atoz_section_label'>S</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/js/mydoc_scroll.html'>Scroll layout</a>
+      <br>
+      <a class='atoz_term' href='/service-stack.html'>Solr Fedora Rails Redis</a>
+      <br>
+      <a class='atoz_term' href='/tag_special_layouts.html'>Special layout pages</a>
+      <br>
+      <a class='atoz_term' href='/search.json'>search</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='t'>&nbsp;</a>
+    <span class='atoz_section_label'>T</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/contribution-tools.html'>TDD & CI, Rubocop, Yard, Inch</a>
+      <br>
+      <a class='atoz_term' href='/best-practices-testing.html'>Testing</a>
+      <br>
+      <a class='atoz_term' href='/touring_hydra_index.html'>Touring the design patterns in Hydra</a>
+      <br>
+      <a class='atoz_term' href='/training/touring_design_patterns/'>Touring the design patterns in Hydra</a>
+      <br>
+      <a class='atoz_term' href='/design_patterns.html'>Touring the design patterns in Hyrax</a>
+      <br>
+      <a class='atoz_term' href='/training.html'>Training</a>
+      <br>
+      <a class='atoz_term' href='/troubleshooting-production.html'>Troubleshooting Production</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='u'>&nbsp;</a>
+    <span class='atoz_section_label'>U</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/customize-metadata-controller.html'>Understanding the Controller</a>
+      <br>
+      <a class='atoz_term' href='/best-practices-modules.html'>Use of Modules</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='v'>&nbsp;</a>
+    <span class='atoz_section_label'>V</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/access-controls.html'>Visibility and Access Controls</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='w'>&nbsp;</a>
+    <span class='atoz_section_label'>W</span>
+    <div class='atoz_terms'>
+      <a class='atoz_term' href='/what-are-things.html'>What Are the Things?</a>
+      <br>
+      <a class='atoz_term' href='/what-happens-deposit-1.0.html'>What Happens When I Deposit Something?</a>
+      <br>
+      <a class='atoz_term' href='/what-happens-deposit-2.0.html'>What Happens When I Deposit Something?</a>
+      <br>
+      <a class='atoz_term' href='/what-happens-edit.html'>What Happens When I Edit Something?</a>
+      <br>
+      <a class='atoz_term' href='/what-happens-index.html'>What Happens When I Index Something?</a>
+      <br>
+      <a class='atoz_term' href='/what-happens-search.html'>What Happens When I Search For Something?</a>
+      <br>
+      <a class='atoz_term' href='/what-happens-view.html'>What Happens When I View Something?</a>
+      <br>
+      <a class='atoz_term' href='/solutions.html'>What Solutions are Available?</a>
+      <br>
+      <a class='atoz_term' href='/why-hydra.html'>Why Hydra?</a>
+      <br>
+      <a class='atoz_term' href='/workflow_and_mediated_deposit.html'>Workflow and Mediated Deposit in Hyrax 1.x</a>
+      <br>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='x'>&nbsp;</a>
+    <span class='atoz_section_label'>X</span>
+    <div class='atoz_terms'>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='y'>&nbsp;</a>
+    <span class='atoz_section_label'>Y</span>
+    <div class='atoz_terms'>
+    </div>
+  </div>
+  <div class='atoz_section'>
+    <a class='atoz_anchor' name='z'>&nbsp;</a>
+    <span class='atoz_section_label'>Z</span>
+    <div class='atoz_terms'>
+    </div>
+  </div>
+</div>

--- a/pages/hydra/developer_resources/best_practices/coding_style.md
+++ b/pages/hydra/developer_resources/best_practices/coding_style.md
@@ -1,11 +1,12 @@
 ---
 title: "Coding Style with RuboCop"
-keywords: Best Practices
-categories: How to Do All the Things
 permalink: best-practices-coding-styles.html
 folder: hydra/how-to/best_practices/coding_styles.md
 sidebar: home_sidebar
+a-z: ['Coding Styles', 'Rubocop']
+keywords: Best Practices
 tags: [development_resources]
+categories: How to Do All the Things
 ---
 
 # Importance of Consistent Coding Styles

--- a/pages/hydra/developer_resources/customize_metadata/hyrax_1.0/controlled-vocabulary.md
+++ b/pages/hydra/developer_resources/customize_metadata/hyrax_1.0/controlled-vocabulary.md
@@ -6,6 +6,7 @@ permalink: customize-metadata-controlled-vocabulary.html
 folder: hydra/how-to/customize_metadata/hyrax_1.0/controlled-vocabulary.md
 sidebar: home_sidebar
 tags: [development_resources]
+a-z: ['Customizing Metadata (Controlled Vocabularies)', 'Controlled Vocabularies (Customizing Metadata)'] 
 ---
 
 NOTE: Please note that this documentation applies to Hyrax 1.0.


### PR DESCRIPTION
### How to generate the index...
```
jekyll build
cp generated/atoz.md pages
```
Then commit pages/atoz.md to github.

### What gets indexed?
#### Default
The title gets indexed by default.  We can turn that off once we have the a-z custom terms defined for all the pages.

Why would we want to turn off titles?  Some pages have the same title when there is documentation for multiple versions.

#### Custom Terms
Additional terms for a page can be added to the index by specifying term labels in the a-z front matter.
```
a-z: ['Customizing Metadata (Controlled Vocabularies)', 'Controlled Vocabularies (Customizing Metadata)']
```
See this example in [pages/hydra/developer_resources/customize_metadata/hyrax_1.0/controlled-vocabulary.md](https://raw.githubusercontent.com/samvera/samvera.github.io/master/pages/hydra/developer_resources/customize_metadata/hyrax_1.0/controlled-vocabulary.md)