### PR TITLE
Add html-proofer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ source "https://rubygems.org"
 
 # gem 'github-pages', group: :jekyll_plugins
 gem 'github-pages' # plugins will not run if group: :jekyll_plugins is used
-
+gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorator (1.1.0)
+    colored (1.2)
     ethon (0.10.1)
       ffi (>= 1.3.0)
     execjs (2.7.0)
@@ -73,6 +74,15 @@ GEM
     html-pipeline (2.5.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (3.7.2)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.7)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
     i18n (0.8.1)
     jekyll (3.4.3)
       addressable (~> 2.4)
@@ -169,6 +179,7 @@ GEM
       mini_portile2 (~> 2.1.0)
     octokit (4.6.2)
       sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.11.2)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -189,12 +200,14 @@ GEM
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
     unicode-display_width (1.1.3)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-pages
+  html-proofer
 
 BUNDLED WITH
-   1.14.6
+   1.15.1


### PR DESCRIPTION
This allows editors of the site to check for broken links (and more) before pushing changes. See PR description for usage instructions and current output in `master`:

# How to Invoke

```
bundle install
htmlproofer ./_site/ --url-ignore "/#.*/"
```

The `--url-ignore` option allows for ignore hash URIs, which generate hundreds of errors particularly for JavaScript links.

[More on htmlproofer](https://github.com/gjtorikian/html-proofer)

# Current Output

The current output of the above command (which may be mined for creating new issues):

```
Running ["LinkCheck", "ImageCheck", "ScriptCheck"] on ["./_site/"] on *.html... 


Checking 140 external links...
Ran on 79 files!


- ./_site/building-searches.html
  *  External link http://samvera.github.iofeed.xml failed: response code 0 means something's wrong.
             It's possible libcurl couldn't connect to the server or perhaps the request timed out.
             Sometimes, making too many requests at once also breaks things.
             Either way, the return message (if any) from the server is: Couldn't resolve host name
- ./_site/code.html
  *  internally linking to formalities.md, which does not exist (line 668)
     <a href="formalities.md">formalities</a>
- ./_site/communication.html
  *  External link https://curationexperts.com/our-services/samvera-camp failed: 404 No error
- ./_site/customize-metadata-controlled-vocabulary.html
  *  External link https://github.com/samvera-labs/questioning_authority failed: 404 No error
- ./_site/deeper_samvera_index.html
  *  External link http://localhost:3000 failed: got a time out (response code 0)
  *  External link http://localhost:5678 failed: got a time out (response code 0)
  *  External link https://github.com/samvera-labs/curation_concerns failed: 404 No error
  *  External link https://github.com/samvera-labs/hydra-works failed: 404 No error
  *  image images/legacy_HABTM.svg does not have an alt attribute (line 56)
  *  image images/legacy_modeling.svg does not have an alt attribute (line 51)
  *  image images/ore_proxy.jpg does not have an alt attribute (line 278)
  *  image images/outdated_hydra_works.png does not have an alt attribute (line 75)
  *  image images/stonehenge.png does not have an alt attribute (line 38)
- ./_site/dive-deeper.html
  *  image images/legacy_modeling.svg does not have an alt attribute (line 649)
- ./_site/formalities.html
  *  internally linking to communication.md, which does not exist (line 676)
     <a href="communication.md">communication channels</a>
- ./_site/get-help.html
  *  Samvera Wiki (this site) http://wiki.duraspace.org/display/samvera is an invalid URL (line 757)
     <a href="Samvera%20Wiki%20(this%20site)%20http://wiki.duraspace.org/display/samvera">DuraSpace Wiki</a>
  *  internally linking to samvera-steering@googlegroups.com, which does not exist (line 697)
     <a href="samvera-steering@googlegroups.com">e-mail</a>
- ./_site/js/mydoc_scroll.html
  *  internal image images/company_logo.png does not exist (line 916)
  *  internal script js/customscripts.js does not exist (line 27)
  *  internal script js/jekyll-search.js does not exist (line 117)
  *  internal script js/jquery.navgoco.min.js does not exist (line 21)
  *  internal script js/toc.js does not exist (line 26)
  *  internally linking to a-z.html, which does not exist (line 617)
     <a href="a-z.html">A-Z Index</a>
  *  internally linking to access-controls.html, which does not exist (line 494)
     <a href="access-controls.html">Access Controls and Visibility</a>
  *  internally linking to add-new-work-type.html, which does not exist (line 417)
     <a href="add-new-work-type.html">How Do I Add a New Work Type?</a>
  *  internally linking to admin-users.html, which does not exist (line 377)
     <a href="admin-users.html">Database-backed Setup</a>
  *  internally linking to aws.html, which does not exist (line 551)
     <a href="aws.html">Amazon Web Services</a>
  *  internally linking to background-jobs.html, which does not exist (line 508)
     <a href="background-jobs.html">Working With Background Jobs</a>
  *  internally linking to best-practices-coding-styles.html, which does not exist (line 292)
     <a href="best-practices-coding-styles.html">Coding Style with RuboCop</a>
  *  internally linking to best-practices-modules.html, which does not exist (line 304)
     <a href="best-practices-modules.html">Use of Module Includes</a>
  *  internally linking to best-practices-testing.html, which does not exist (line 298)
     <a href="best-practices-testing.html">Testing</a>
  *  internally linking to blacklight-plugins.html, which does not exist (line 246)
     <a href="blacklight-plugins.html">Other Blacklight Plugins</a>
  *  internally linking to building-searches.html, which does not exist (line 487)
     <a href="building-searches.html">How Do I Build Searches?</a>
  *  internally linking to contribution-tools.html, which does not exist (line 594)
     <a href="contribution-tools.html">Contribution Tools</a>
  *  internally linking to css/customstyles.css, which does not exist (line 16)
     <link rel="stylesheet" href="css/customstyles.css">
  *  internally linking to css/lavish-bootstrap.css, which does not exist (line 15)
     <link rel="stylesheet" href="css/lavish-bootstrap.css">
  *  internally linking to css/modern-business.css, which does not exist (line 14)
     <link rel="stylesheet" href="css/modern-business.css">
  *  internally linking to css/syntax.css, which does not exist (line 9)
     <link rel="stylesheet" href="css/syntax.css">
  *  internally linking to css/theme-blue.css, which does not exist (line 17)
     <link rel="stylesheet" href="css/theme-blue.css">
  *  internally linking to customize-metadata-controlled-vocabulary.html, which does not exist (line 433)
     <a href="customize-metadata-controlled-vocabulary.html">Prereq: Defining a Controlled Vocabulary</a>
  *  internally linking to customize-metadata-controller.html, which does not exist (line 445)
     <a href="customize-metadata-controller.html">Understanding the Controller</a>
  *  internally linking to customize-metadata-discovery.html, which does not exist (line 469)
     <a href="customize-metadata-discovery.html">Configuring Discovery</a>
  *  internally linking to customize-metadata-edit-form.html, which does not exist (line 457)
     <a href="customize-metadata-edit-form.html">Modifying the Edit Form</a>
  *  internally linking to customize-metadata-generate-work-type.html, which does not exist (line 427)
     <a href="customize-metadata-generate-work-type.html">Prereq: Generating a Work Type</a>
  *  internally linking to customize-metadata-labels.html, which does not exist (line 439)
     <a href="customize-metadata-labels.html">Labels and Help Text</a>
  *  internally linking to customize-metadata-model.html, which does not exist (line 451)
     <a href="customize-metadata-model.html">Defining Metadata in the Model</a>
  *  internally linking to customize-metadata-other-customizations.html, which does not exist (line 475)
     <a href="customize-metadata-other-customizations.html">Other Metadata Customizations</a>
  *  internally linking to customize-metadata-show-page.html, which does not exist (line 463)
     <a href="customize-metadata-show-page.html">Modifying the Show Page</a>
  *  internally linking to deeper_samvera_index.html, which does not exist (line 204)
     <a href="deeper_samvera_index.html">Dive Deeper Into Samvera (Slideshow)</a>
  *  internally linking to devops.html, which does not exist (line 558)
     <a href="devops.html">DevOps</a>
  *  internally linking to extend-hyrax.html, which does not exist (line 316)
     <a href="extend-hyrax.html">Extending Hyrax</a>
  *  internally linking to get-help.html, which does not exist (line 190)
     <a href="get-help.html">How to Ask for Help</a>
  *  internally linking to getting_started.html, which does not exist (line 176)
     <a href="getting_started.html">Up and Running</a>
  *  internally linking to groups.html, which does not exist (line 371)
     <a href="groups.html">Default Setup</a>
  *  internally linking to hardware-considerations.html, which does not exist (line 537)
     <a href="hardware-considerations.html">Hardware Considerations</a>
  *  internally linking to how-to-pr.html, which does not exist (line 601)
     <a href="how-to-pr.html">How to Submit Pull Reqeusts</a>
  *  internally linking to hyku-vs-hyrax.html, which does not exist (line 239)
     <a href="hyku-vs-hyrax.html">Hyku vs Hyrax</a>
  *  internally linking to hyrax-out-of-the-box.html, which does not exist (line 275)
     <a href="hyrax-out-of-the-box.html">Hyrax Out of the Box</a>
  *  internally linking to hyrax-releases.html, which does not exist (line 587)
     <a href="hyrax-releases.html">Releases</a>
  *  internally linking to images/favicon.ico, which does not exist (line 29)
     <link rel="shortcut icon" href="images/favicon.ico">
  *  internally linking to index.html, which does not exist (line 91)
     <a class="fa fa-home fa-lg navbar-brand" href="index.html"> <span class="projectTitle"> Hyrax Developer Knowledge Base</span></a>
  *  internally linking to install-hyrax.html, which does not exist (line 268)
     <a href="install-hyrax.html">Install Hyrax</a>
  *  internally linking to introduction.html, which does not exist (line 169)
     <a href="introduction.html">Introduction</a>
  *  internally linking to other-getting-started.html, which does not exist (line 197)
     <a href="other-getting-started.html">Other Helpful Getting Started Docs</a>
  *  internally linking to our_technology_stack.html, which does not exist (line 183)
     <a href="our_technology_stack.html">Our Technology Stack</a>
  *  internally linking to participants.html, which does not exist (line 405)
     <a href="participants.html">Participants</a>
  *  internally linking to pcdm.html, which does not exist (line 515)
     <a href="pcdm.html">Working With PCDM</a>
  *  internally linking to plugins.html, which does not exist (line 522)
     <a href="plugins.html">Writing Hyrax Plugins</a>
  *  internally linking to quality.html, which does not exist (line 218)
     <a href="quality.html">Quality Practices</a>
  *  internally linking to real-life-hyrax.html, which does not exist (line 580)
     <a href="real-life-hyrax.html">Real Life Hyrax</a>
  *  internally linking to service-stack.html, which does not exist (line 544)
     <a href="service-stack.html">Samvera Services Stack</a>
  *  internally linking to solutions.html, which does not exist (line 232)
     <a href="solutions.html">Solutions</a>
  *  internally linking to toggle-features.html, which does not exist (line 282)
     <a href="toggle-features.html">Enabling Features</a>
  *  internally linking to touring_samvera_index.html, which does not exist (line 211)
     <a href="touring_samvera_index.html">Samvera Design Patterns (Slideshow)</a>
  *  internally linking to training.html, which does not exist (line 253)
     <a href="training.html">Training</a>
  *  internally linking to troubleshooting-production.html, which does not exist (line 565)
     <a href="troubleshooting-production.html">Troubleshooting Production</a>
  *  internally linking to what-are-admin-things.html, which does not exist (line 399)
     <a href="what-are-admin-things.html">Key Terms</a>
  *  internally linking to what-are-things.html, which does not exist (line 389)
     <a href="what-are-things.html">What Are The Main Things</a>
  *  internally linking to what-happens-deposit-1.0.html, which does not exist (line 326)
     <a href="what-happens-deposit-1.0.html">I Deposit Something (1.0)</a>
  *  internally linking to what-happens-deposit-2.0.html, which does not exist (line 332)
     <a href="what-happens-deposit-2.0.html">I Deposit Something (2.0)</a>
  *  internally linking to what-happens-edit.html, which does not exist (line 338)
     <a href="what-happens-edit.html">I Edit Something</a>
  *  internally linking to what-happens-index.html, which does not exist (line 350)
     <a href="what-happens-index.html">I Index Something</a>
  *  internally linking to what-happens-search.html, which does not exist (line 344)
     <a href="what-happens-search.html">I Search for Something</a>
  *  internally linking to what-happens-view.html, which does not exist (line 356)
     <a href="what-happens-view.html">I View Something</a>
  *  internally linking to why-samvera.html, which does not exist (line 225)
     <a href="why-samvera.html">Why Samvera?</a>
  *  internally linking to workflow_and_mediated_deposit.html, which does not exist (line 501)
     <a href="workflow_and_mediated_deposit.html">Workflow and Mediated Deposit</a>
- ./_site/review.html
  *  internally linking to code.md, which does not exist (line 666)
     <a href="code.md">code guidelines</a>
- ./_site/tag_special_layouts.html
  *  internally linking to jsmydoc_scroll.html, which does not exist (line 834)
     <a href="jsmydoc_scroll.html">Scroll layout</a>
- ./_site/touring_samvera_index.html
  *  image images/agile_software_development.jpg does not have an alt attribute (line 68)
- ./_site/training/deeper_into_samvera/index.html
  *  image legacy_HABTM.svg does not have an alt attribute (line 56)
  *  image legacy_modeling.svg does not have an alt attribute (line 51)
  *  image ore_proxy.jpg does not have an alt attribute (line 277)
  *  image outdated_hydra_works.png does not have an alt attribute (line 75)
  *  image stonehenge.png does not have an alt attribute (line 38)
- ./_site/training/touring_design_patterns/index.html
  *  image agile_software_development.jpg does not have an alt attribute (line 68)
htmlproofer 3.7.2 | Error:  HTML-Proofer found 95 failures!
```