### PR TITLE
update a-z index

### DIFF
--- a/pages/deeper_samvera_index.html
+++ b/pages/deeper_samvera_index.html
@@ -2,7 +2,7 @@
 layout: deck
 title: "Dive Deeper into Samvera"
 a-z: ["Dive Deeper into Samvera"]
-permalink: /deeper_hydra_index.html
+permalink: /deeper_samvera_index.html
 ---
 
 <section class="slide" id="title-slide">

--- a/pages/samvera/1_new_start_here/why-samvera.md
+++ b/pages/samvera/1_new_start_here/why-samvera.md
@@ -1,6 +1,6 @@
 ---
 title:  "Why Samvera?"
-a-z:  "Why Samvera?"
+a-z:  ["Why Samvera?"]
 keywords: Preservation and Discovery
 permalink: why-samvera.html
 folder: samvera/getting_started/why-samvera.md

--- a/pages/touring_samvera_index.html
+++ b/pages/touring_samvera_index.html
@@ -2,7 +2,7 @@
 layout: deck
 title: "Touring the design patterns in Samvera"
 a-z: ["Touring the design patterns in Samvera"]
-permalink: /touring_hydra_index.html
+permalink: /touring_samvera_index.html
 ---
 
 <section class="slide" id="title-slide">


### PR DESCRIPTION
NOTE: I started to leave `pages/deeper_samvera_index.html` and ` pages/touring_samvera_index.html` due to the request in Issue #27 'Make sure links to legacy content still work after we migrate to new docs', but they were already broken when we switched from http://hydra.github.io to http://samvera.github.io.

Perhaps we need to revisit #27.
 