### PR TITLE
Update Basic Metadata and Core Metadata sections of "Defining Metadat…

### DIFF
--- a/pages/samvera/developer_resources/customize_metadata/hyrax_1.0/model.md
+++ b/pages/samvera/developer_resources/customize_metadata/hyrax_1.0/model.md
@@ -31,19 +31,20 @@ end
 
 ### Basic metadata
 
-Basic metadata properties are defined in [app/models/concerns/hyrax/basic_metadata.rb](https://github.com/samvera/hyrax/blob/master/app/models/concerns/hyrax/basic_metadata.rb)
+Basic metadata properties are defined in [app/models/concerns/hyrax/basic_metadata.rb](https://github.com/samvera/hyrax/blob/1-0-stable/app/models/concerns/hyrax/basic_metadata.rb)
 
 | Property | Predicate | Multiple |
 | -------- | --------- | -------- |
 | label | ActiveFedora::RDF::Fcrepo::Model.downloadFilename | **FALSE** |
 | relative_path | ::RDF::URI.new('http://scholarsphere.psu.edu/ns#relativePath') | **FALSE** |
 | import_url | ::RDF::URI.new('http://scholarsphere.psu.edu/ns#importUrl') | **FALSE** |
+| part_of | ::RDF::Vocab::DC.isPartOf | TRUE |
 | resource_type | ::RDF::Vocab::DC.type | TRUE |
 | creator | ::RDF::Vocab::DC11.creator | TRUE |
 | contributor | ::RDF::Vocab::DC11.contributor | TRUE |
 | description | ::RDF::Vocab::DC11.description | TRUE |
 | keyword | ::RDF::Vocab::DC11.relation | TRUE |
-| license | ::RDF::Vocab::DC.rights | TRUE |
+| rights | ::RDF::Vocab::DC.rights | TRUE |
 | rights_statement | ::RDF::Vocab::EDM.rights | TRUE |
 | publisher | ::RDF::Vocab::DC11.publisher | TRUE |
 | date_created | ::RDF::Vocab::DC.created | TRUE |
@@ -57,11 +58,11 @@ Basic metadata properties are defined in [app/models/concerns/hyrax/basic_metada
 
 ### Core metadata
 
-Core metadata properties (**_that should never be removed_**) are defined in [app/models/concerns/hyrax/core_metadata.rb](https://github.com/samvera/hyrax/blob/master/app/models/concerns/hyrax/core_metadata.rb)
+Core metadata properties (**_that should never be removed_**) are defined in [app/models/concerns/hyrax/required_metadata.rb](https://github.com/samvera/hyrax/blob/1-0-stable/app/models/concerns/hyrax/required_metadata.rb)
 
 | Property | Predicate | Multiple |
 | -------- | --------- | -------- |
-| depositor | ::RDF::Vocab::MARCRelators.dpt | **FALSE** |
+| depositor | ::RDF::URI.new('http://id.loc.gov/vocabulary/relators/dpt') | **FALSE** |
 | title | ::RDF::Vocab::DC.title | TRUE |
 | date_uploaded | ::RDF::Vocab::DC.dateSubmitted | **FALSE** |
 | date_modified | ::RDF::Vocab::DC.modified | **FALSE** |


### PR DESCRIPTION
…a in the Model" page to reflect Hyrax 1.0-stable accurately; closes #126.

In Hyrax 1, "Core" Metadata is possibly more accurately referred to as "Required" Metadata since that is the name of Hyrax 1 class that contains it.
However, I left the "core" language as it was since I thought "required metadata" might be ambiguous and since that is how Hyrax 2 will refer to it.