### PR TITLE
Adding documentation about customizing workflows

### DIFF
--- a/pages/samvera/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_and_mediated_deposit.md
+++ b/pages/samvera/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_and_mediated_deposit.md
@@ -108,9 +108,9 @@ w.setup
 ```
 Putting this code in `db/seeds.rb` means it will be called at the end of `bin/setup`, and you can call it anytime via `rake db:seed`
 
-## How do I assign reviewers for my ETDs without creating lots of AdminSets?
+## How do I assign reviewers for a deposited work (e.g. ETDs) without creating lots of AdminSets?
 
-Create a [Sipity::Method][sipity_method] to assign a reviewer based on the ETDs department.
+Create a [Sipity::Method][sipity_method] to assign a reviewer based on some property of the deposited work (e.g. reviewers based on the work's department).
 
 Before getting into the specifics of how to do this, let's do a quick overview of some key workflow concepts for this problem.
 
@@ -150,6 +150,8 @@ end
 RSpec.describe Hyrax::Workflow::AssignReviewerByDepartment do
   let(:workflow_method) { described_class }
   it_behaves_like "a Hyrax workflow method"
+
+  # Don't forget to write specs for the business logic of this method
 end
 ```
 

--- a/pages/samvera/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_and_mediated_deposit.md
+++ b/pages/samvera/developer_resources/workflow_and_mediated_deposit/hyrax_1.0/workflow_and_mediated_deposit.md
@@ -110,23 +110,25 @@ Putting this code in `db/seeds.rb` means it will be called at the end of `bin/se
 
 ## How do I assign reviewers for my ETDs without creating lots of AdminSets?
 
-**Goal: Assigning a person to review a submission based on properties of the work.** *And you don't need multiple admin sets to do this.*
+Create a [Sipity::Method][sipity_method] to assign a reviewer based on the ETDs department.
 
-### Whirlwind Workflow
+Before getting into the specifics of how to do this, let's do a quick overview of some key workflow concepts for this problem.
 
-Two primary concepts of the workflow in Hyrax 1.0:
+### Quick Overview of Workflow
+
+For this particular issue, there are three primary concepts that you may want to reference:
 
 1) Permissions are assigned at two levels:
   1) [Sipity::WorkflowResponsibility][sipity_workflow_responsibility] - A person has permissions to all things using this workflow
   1) [Sipity::EntitySpecificResponsibility][sipity_entity_specific_responsibility] - A person has permissions to only the work/entity
-2) [Sipity::Method][sipity_method] - Something we "call" when we take a Sipity::Action.
-3) [Hyrax::Workflow::PermissionGenerator][hyrax_workflow_permission_generator]
+2) [Sipity::Method][sipity_method] - Something we `.call` when we take a Sipity::Action.
+3) [Hyrax::Workflow::PermissionGenerator][hyrax_workflow_permission_generator] - Responsible for assigning permissions. **This could be bettern named as Hyrax::Workflow::PermissionAssigner**
 
 ### How to Do This
 
-You'll need to understand the [JSON workflow schema][json_workflow_schema]. See the [default workflow][template_workflows] of the method called when a user deposits a work: One method object, [Hyrax::Workflow::GrantEditToDepositor][hyrax_workflow_grant_edit_to_depositor], grants the user depositing rights for the deposit worked (eg. Sipity::EntitySpecificResponsibility).
+Referencing the [default workflow][template_workflows] there is a method object that is called when a user deposits a work: One method object, [Hyrax::Workflow::GrantEditToDepositor][hyrax_workflow_grant_edit_to_depositor], grants the user depositing rights for the deposit worked (eg. Sipity::EntitySpecificResponsibility).
 
-You'll need to modify the workflow (an exercise left up to the reader) to include a method for the appropriate action.
+You'll need to modify your workflow (an exercise left up to the reader) to include a method for the appropriate action. You may want to reference the [JSON workflow schema][json_workflow_schema] for proper syntax.
 
 Then create (and test) your method object.
 


### PR DESCRIPTION
Based on a conversation @julesies, I wrote up some documentation about
how to customize workflows to reduce the need for duplication of
AdminSets.

Questions:

* Is this the right place? (Or should we have a more general how to
  section)
* Is this adequate? Or too much?

I provided context of workflow as it relates to solving this
requirement.