### PR TITLE
Adding a placeholder Rake task for Travis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ source "https://rubygems.org"
 # gem 'github-pages', group: :jekyll_plugins
 gem 'github-pages' # plugins will not run if group: :jekyll_plugins is used
 gem 'html-proofer'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,7 @@ GEM
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
+    rake (12.3.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -207,6 +208,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   html-proofer
+  rake
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+# A placeholder while we work on getting Travis building the actual
+# Jekyll site. See PR https://github.com/samvera/samvera.github.io/pull/154
+task :default do
+  $stdout.puts "A placeholder task until https://github.com/samvera/samvera.github.io/pull/154 is resolved."
+end


### PR DESCRIPTION
We are aspiring to check the built website as part of the pull request
process. However, there are two steps:

1) Activating Travis
2) Having Travis check the Website

As of this commit we have activated travis, but do not have a task for
checking the website (that is part of PR #154). This is a placeholder
solution until we resolve the technical issues of the other PR.

Related to #154