### PR TITLE
Fixing Invalid YAML Syntax in Managers Guide

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -275,71 +275,71 @@ entries:
     output: web, pdf
     folderitems:
 
-        - title: What's New in Hyrax 2.0?
-          url: /whats-new.html
+    - title: What's New in Hyrax 2.0?
+      url: /whats-new.html
+      output: web, pdf
+
+      subfolders:
+      - title: Hyrax 2.0
+        output: web
+        subfolderitems:
+
+        - title: Concepts and Definitions
+          url: /concepts-2.0.html
           output: web, pdf
 
-        subfolders:
-          - title: Hyrax 2.0
-            output: web
-            subfolderitems:
+        - title: Configuration
+          url: /configuration.html
+          output: web, pdf
 
-            - title: Concepts and Definitions
-              url: /concepts-2.0.html
-              output: web, pdf
+        - title: Creating a Work
+          url: /create-works-2.0.html
+          output: web, pdf
 
-            - title: Configuration
-              url: /configuration.html
-              output: web, pdf
+        - title: Editing a Work
+          url: /edit-works-2.0.html
+          output: web, pdf
 
-            - title: Creating a Work
-              url: /create-works-2.0.html
-              output: web, pdf
+        - title: Administrative Sets
+          url: /admin-sets-2.0.html
+          output: web, pdf
 
-            - title: Editing a Work
-              url: /edit-works-2.0.html
-              output: web, pdf
+        - title: Collections
+          url: /collections-2.0.html
+          output: web, pdf
 
-            - title: Administrative Sets
-              url: /admin-sets-2.0.html
-              output: web, pdf
+        - title: Batch Uploading Works
+          url: /batch-works-2.0.html
+          output: web, pdf
 
-            - title: Collections
-              url: /collections-2.0.html
-              output: web, pdf
+      subfolders:
+      - title: Hyrax 1.0
+        output: web
+        subfolderitems:
 
-            - title: Batch Uploading Works
-              url: /batch-works-2.0.html
-              output: web, pdf
+        - title: Concepts and Definitions
+          url: /concepts-1.0.html
+          output: web, pdf
 
-          subfolders:
-              - title: Hyrax 1.0
-                output: web
-                subfolderitems:
+        - title: Creating a Work
+          url: /create-works-1.0.html
+          output: web, pdf
 
-            - title: Concepts and Definitions
-              url: /concepts-1.0.html
-              output: web, pdf
+        - title: Editing a Work
+          url: /edit-works-1.0.html
+          output: web, pdf
 
-            - title: Creating a Work
-              url: /create-works-1.0.html
-              output: web, pdf
+        - title: Administrative Sets
+          url: /admin-sets-1.0.html
+          output: web, pdf
 
-            - title: Editing a Work
-              url: /edit-works-1.0.html
-              output: web, pdf
+        - title: Collections
+          url: /collections-1.0.html
+          output: web, pdf
 
-            - title: Administrative Sets
-              url: /admin-sets-1.0.html
-              output: web, pdf
-
-            - title: Collections
-              url: /collections-1.0.html
-              output: web, pdf
-
-            - title: Batch Uploading Works
-              url: /batch-works-1.0.html
-              output: web, pdf
+        - title: Batch Uploading Works
+          url: /batch-works-1.0.html
+          output: web, pdf
 
   - title: User Interface Testing
     output: web, pdf

--- a/pages/samvera/manager_guide/hyrax_1.0/batch-works-1.0.md
+++ b/pages/samvera/manager_guide/hyrax_1.0/batch-works-1.0.md
@@ -9,6 +9,7 @@ tags: [user_resources]
 categories: How to use the Administration panel in hyrax
 version:
   id: 'hyrax_1.0-stable'
+  versions:
   - label: 'Hyrax 1.0'
     link:  'collections-1.0.html'
     selected: 'true'

--- a/pages/samvera/manager_guide/hyrax_1.0/edit-works-1.0.md
+++ b/pages/samvera/manager_guide/hyrax_1.0/edit-works-1.0.md
@@ -9,6 +9,7 @@ tags: [user_resources]
 categories: How to use the Administration panel in hyrax
 version:
   id: 'hyrax_1.0-stable'
+  versions:
   - label: 'Hyrax 1.0'
     link:  'edit-works-1.0.html'
     selected: 'true'

--- a/pages/samvera/manager_guide/hyrax_2.0/batch-works-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/batch-works-2.0.md
@@ -9,10 +9,11 @@ tags: [user_resources]
 categories: How to use the Administration panel in hyrax
 version:
   id: 'hyrax_1.0-stable'
+  versions:
   - label: 'Hyrax 1.0'
     link:  'collections-1.0.html'
-    label: 'Hyrax 2.0'
-  - link:  'collections-2.0.html'
+  - label: 'Hyrax 2.0'
+    link:  'collections-2.0.html'
     selected: 'true'
 ---
 


### PR DESCRIPTION
YAML syntax errors in home_sidebar and a few pages in the manager guide were preventing the site from building properly.

#151 caused build failures, but this should clean things up