### PR TITLE
Adding PassengerAllowEncodedSlashes setting allows default admin set …

### DIFF
--- a/pages/samvera/running_in_production/troubleshooting-production.md
+++ b/pages/samvera/running_in_production/troubleshooting-production.md
@@ -8,3 +8,16 @@ folder: samvera/production/
 sidebar: home_sidebar
 tags: [production]
 ---
+
+# Known gotchas
+
+## displaying default admin set raises exception
+Hyrax creates a default admin set that has a slash in its id ("admin_set/default").
+This means that unless your webserver is configured to allow encoded slashes, 
+features that refer to the default admin set in the url will raise an exception.
+If you are using passenger on Ubuntu, you can fix this by adding this line to 
+`/etc/apache2/conf-enabled/passenger.conf`:
+```
+  PassengerAllowEncodedSlashes on
+```
+The actual syntax might vary depending on your webserver configuration.


### PR DESCRIPTION
…to display

This is a commonly encountered issue when setting up Hyrax.
See https://github.com/samvera/hyrax/issues/2446
for more context.