### PR TITLE
adding a coordinating the release testing process page

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -67,14 +67,19 @@ entries:
       url: /real-life-hyrax.html
       output: web, pdf
 
-    - title: Releases
-      url: /hyrax-releases.html
-      output: web, pdf
+      subfolders:
+      - title: Releases
+        output: web, pdf
+        subfolderitems:
 
-    - title: Release Testing
-      url: /release_testing.html
-      output: web, pdf
-      
+        - title: Release Process
+          url: /release_process.html
+          output: web, pdf
+
+        - title: Release Testing
+          url: /release_testing.html
+          output: web, pdf
+
     - title: Contribution Tools
       url: /contribution-tools.html
       output: web, pdf

--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -71,6 +71,10 @@ entries:
       url: /hyrax-releases.html
       output: web, pdf
 
+    - title: Release Testing
+      url: /release_testing.html
+      output: web, pdf
+      
     - title: Contribution Tools
       url: /contribution-tools.html
       output: web, pdf

--- a/pages/samvera/developer_community/release_process.md
+++ b/pages/samvera/developer_community/release_process.md
@@ -1,0 +1,105 @@
+---
+title: Hyrax Testing and Release Process
+a-z: [Testing, Release Process, Managers, Product Owners]
+last_updated: February 5, 2018
+tags: [release, community]
+sidebar: samvera_sidebar
+permalink: release_process.html
+folder: samvera
+toc: false
+---
+<br />
+
+The [Repository Managers Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group) will work with the Hyrax PO to test and document features for Hyrax releases. For each release cycle, there will be at least one designated person from the Repo-Managers to facilitate the process. [Instructions for conducting release testing can be found here](/release_testing.html) (in progress).
+
+For each cycle the Release Testing facilitator will:
+
+- Communicate with testers and demo site committers about timing of upcoming release.
+- Ensure the Managers Guide, UI Interactions, Test Tracking Spreadsheet and demo site are up to date for the process of testing and documentation.
+- Recruit help with testing, bug reporting and documentation.
+- Ensure testing and documentation is complete.
+
+
+This testing process complements test coverage and regression testing in the code but does not replace it. This testing is meant to facilitate browser, platform, feature, (basic) usability and completion, and accessibility.
+
+### Major release process:
+**Beta Release:** All major features are complete. 2-3 weeks
+
+- Beta release on demo site
+
+- Testing for user acceptance and general readiness for systematic testing (no major issues identified that would impede testing).
+
+- Beta release is announced
+
+- First draft of documentation is done
+
+- First round of testing and bug reporting begins
+
+- Institutions have a chance to report bugs or ask for a PR to be considered for inclusion in release
+
+**Release Candidate:** Feature Freeze and bug fixes only. 2-3 weeks (may be unrealistic time frame?)
+
+- RC goes to demo site
+
+- RC is announced
+
+- Finalize feature documentation by end of phase
+
+- Finalize testing document by end of phase
+
+- Distributed testing of all features, supported browsers, accessibility testing.
+
+- Report bugs
+
+- Confirm bugs (PO?) and determine priority (need to establish process for this)
+
+- Fix all priority bugs
+
+- Repeat above with additional versions of RCx until release is confirmed stable.
+
+**Final Release:**
+
+- Once Final Release is ready, at least 1 in-production institutions should upgrade before wide release (This may not be doable, but would be good if there are institutions willing to do this, could rotate and plan ahead to help curb)
+
+- Final Release is announced widely
+
+### Minor release process:
+
+- Follows the Major release process on a much more compressed timeline.
+
+- Upgrade demo site, retaining data. In the occasion that data needs to be wiped for whatever reason, this is fine. Mostly we want to test that data and users migrate smoothly.  
+
+### Hyrax Shared Testing Tools:
+
+**Demo site:** shared testing and demo instance of Hyrax. Vanilla app with all "bonus" features configured for testing.
+
+  - https://nurax.curationexperts.com hosted by DCE
+  - Github repo: https://github.com/curationexperts/nurax/
+  - Maintained and updated by committers in DCE and Samvera Community
+
+**Hyrax Manager Guide:** describes features, set up and concepts for Hyrax repositories
+
+ - [http://samvera.github.io/](http://samvera.github.io/) ('Manager Guide' in side navigation)
+ - Maintained and updated by the [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group) ask Chris Diaz for more information.
+
+**Hyrax test tracking document:** google doc that helps us track what is tested (including browsers and accessibility) for each release.
+
+-  <this will be shared on the #nurax slack each release> contact Julie Rudder for help.
+- Maintained and updated by the [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group)
+
+
+**Testing list will include the following:**
+
+- All features (including "bonus" features that require configuration)
+- Browsers ([browser version popularity](http://caniuse.com/usage-table))
+
+  - Chrome on Windows
+  - Chrome on Mac OS X
+  - Chrome on Android (for public interactions) (most popular android versions)
+  - Safari on iPhone (for public interactions)
+  - Firefox and Safari should be added (for public interactions?)
+
+- Accessibility
+
+  - Use [http://wave.webaim.org/](http://wave.webaim.org/) (any browser?)
+  - Use Firefox for [NVDA testing](http://nvaccess.org) with a screen reading. Either Windows or Mac

--- a/pages/samvera/developer_community/release_testing.md
+++ b/pages/samvera/developer_community/release_testing.md
@@ -1,0 +1,105 @@
+---
+title: How to Coordinate Testing for a Release
+a-z: [Testing, Release Process]
+last_updated: March 30, 2017
+tags: [release, community]
+sidebar: samvera_sidebar
+permalink: release_testing.html
+folder: samvera
+---
+
+<br />
+<br />
+
+Each release will have a release testing coordinator. This person can vary from release to release. You will work closely with the Hyrax Tech Lead and Product Owner.
+
+Follow the process outlined in [Hyrax Testing and Release Process](https://wiki.duraspace.org/display/samvera/Hyrax+Testing+and+Release+Process). As this is a new process, you may find that some sections need adjustment or more detail.
+
+<br />
+
+**When release is ready:**
+
+  - **Figure out what needs to be tested**
+
+    When a release is ready there will be a list of commits that have been merged since the last release. You may or may not understand the implications of these changes for testing. The tech lead (or others) will be able to help you determine what needs to be tested. In some cases, large community efforts like a shared sprint, may have a person to document how features are supposed to work.
+
+    Here are some common situations to consider:
+
+    Is this a major, minor, or patch release? For major releases we test all the features we can on Nurax across browsers and platforms as well as testing for accessibility. Minor release process is in flux and will likely be determined on a case by case basis. Patch releases will usually happen without your involvement.
+
+    Are there changes to the UI?
+
+    UI updates should have cross browser, platform and accessibility testing. This is not necessary for minor changes like text updates, but does the page look totally different to you? It should be tested!
+
+    Are there updates to core gems that may potential affect certain tasks (like searching, access controls, etc)?
+
+    You will need to work closely with a developer to figure this out. Generally, it would be ideal to do a single browser test of the entire spreadsheet but in some cases this may not be needed.
+
+  - **Make sure Nurax is updated with the release**
+
+    You will hopefully have one or two people that can help get the release on Nurax. Once Nurax is up to date, update the announcement text so people who may be checking out Hyrax (or documenters) know what they are seeing.
+
+  - **Conduct a preliminary test on Nurax**
+
+    Conduct some basic testing to ensure there are not any major problems. (log in, submit a work, edit a work, test the new feature). At this stage you are trying to make sure the release is ready to be tested by the rest of the testing team. You don't want to call on your team to get ready to test if there are major blockers that prohibit testing, for example. This is also a time to work with the PO to make sure new features seem ready to release (user acceptance testing). Any problems you see, document by added issue in Nurax Github and working directly with your Nurax point person or tech lead depending on the release.
+
+  - **Create a testing spreadsheet**
+
+    Create a release version of the testing template spreadsheet and update the spreadsheet with what needs to be tested for each release. Ideally you will run through any new tests before sharing with a larger group. You may have 5 versions of the spreadsheet filled out depending on how many beta and release candidates are in the cycle. You will name them specifically for the release. For example an RC 2 would be called: "Hyrax_2.0.0_testing_spreadsheet_RC2"
+
+    Some common things you will need to consider when creating the spreadsheet:
+
+    1. Browsers/platforms
+    2. Accessibility
+    3. Update an existing tests if any features change
+    4. Add new tests for new feature sets
+    5. Remove tests that are not needed
+
+  - **PIN the testing template to the #nurax channel on slack**
+
+    Right now we aren't posting the URL for the template on this page since it needs to be open.
+
+  - **Identify testers**
+
+    Put a call out to find people to help you test and add their initials to the tasks in first page of the testing spreadsheet. This could be between 3-10 people depending on the size and scope of the release. You want to try to give them a timeline and a target due date. Most testers are busy but able to help out with some notice. Accessibility is particularly tricky to schedule because of limited number of testers, complexity of the test, and timing of the testing. Some places to find testers: repo-managers, UX (accessibility). Please note: the tests will range various roles in the system, some may only be conducted by those with repo-admin status on Nurax. You will need to update the .yml file for anyone who needs this and a deploy to the server will be needed (this should be automatic, but ask your Nurax Helpers if needed).
+
+    Ask your testers to join the #nurax channel on github - this is where they may communicate with other testers and helpers who may be able to resolve bugs and system issues. Some helpers may say "Restarting Nurax, any problems with that?"
+
+- **Conducting testing**
+
+  - Document who is going to test what on the first sheet of the testing spreadsheet. You may want to coordinate a quick call to make sure people are on the same page. Repeat testers will know the drill.
+
+  - Give testers a heads up on the process and make sure you communicate when you'd like testing done by. Even a couple hours of someone's time will be very helpful!
+
+  - Try not to help people too much, you want to make sure people are going to uncover issues and you might 'know exactly how to do something'. Testers are capturing their problems so we can surface issues. They can comment directly in the spreadsheet.
+
+  - Also, try not to assign yourself any tests if possible - you will be very busy during this phase verifying bugs, triaging tickets and helping testers.
+
+  - **Accessibility testing**
+
+    - The timing of accessibility testing is important, because you want to make sure you balance a well-working system (no major bugs) and giving time for testers to do their work. These tests are specialized and need people who have an understanding of what to test and how to determine what pass/fail looks like.
+
+  - **Admin set issues**
+
+    - Because Hyrax deposits to the last admin set created, you've got to really make sure the test specify what admin set to use depending on what you are testing for. Since part of testing is creating new admin sets (with various settings), you will never really know what is going on with the settings on release, visibility, and mediation there will be. "Default Admin Set" should have no restrictions and can be used for general tests.
+
+  - **Repository Admin testing**
+
+    - With the "flippable" features, the Repository Administration test must make sure 1) they announce on Nurax before they test (since they will be turning features on and off) and 2) they return settings to the original settings.
+
+- **Bug reports/Triage Process**
+
+  - Ask testers to report bugs directly in [the github issues](https://github.com/curationexperts/nurax/issues)
+  - You will work very closely with PO/Tech lead to label, verify, and close issues related to bugs. You may meet 1 time a week to go through issues.
+  - One approach you can take is: Verify each bug and give it an appropriate label. Coordinate with PO/Tech Lead to move "must fix" issues to Hyrax Issues.
+  - Once bugs are fixed, code must be updated on Nurax, you must retest on Nurax.
+  - Close Nurax Issues, once bug is confirmed fixed on Nurax.
+
+- **How do you know when the release is "done"?**
+
+  - This will be determined by the PO and Technical Lead signing off that all blocker issues are successfully resolved.
+  - In addition, you will want to help make sure the targets are ready for documentation mentioned here.  Although you are not responsible for creating documentation, it's helpful for you to communicate when testing.
+
+- **Stuff you can't test**
+
+  There are few things you can't test, like "real time notification" or any email notification feature (like contact us forms!). This is because Nurax is does not have a SMTP server set up and has a particular configuration that might affect your ability to test everything. This is okay, please note anything that you can not test.

--- a/pages/samvera/developer_community/release_testing.md
+++ b/pages/samvera/developer_community/release_testing.md
@@ -13,7 +13,7 @@ folder: samvera
 
 Each release will have a release testing coordinator. This person can vary from release to release. You will work closely with the Hyrax Tech Lead and Product Owner.
 
-Follow the process outlined in [Hyrax Testing and Release Process](https://wiki.duraspace.org/display/samvera/Hyrax+Testing+and+Release+Process). As this is a new process, you may find that some sections need adjustment or more detail.
+Follow the newly-defined process outlined in [Hyrax Testing and Release Process](/release_process.html). As this is a new process, you may find that some sections need adjustment or more detail.
 
 <br />
 


### PR DESCRIPTION
Adding this content: https://wiki.duraspace.org/display/samvera/How+to+coordinate+testing+for+a+release, and https://wiki.duraspace.org/display/samvera/Hyrax+Testing+and+Release+Process -- under Developer Community/ Releases