### PR TITLE
update lease-embargoes-2.0

### DIFF
--- a/pages/samvera/manager_guide/hyrax_2.0/lease-embargoes-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/lease-embargoes-2.0.md
@@ -13,7 +13,29 @@ version:
 
 *This Guide is maintained by Samvera's [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group). Screenshots are taken from [Nurax](https://nurax.curationexperts.com/), a testing repository running on the latest release of Hyrax. Hosting is generously provided by [Data Curation Experts](https://curationexperts.com/). Please open an issue on our [GitHub repository](https://github.com/samvera/samvera.github.io) to request edits or additions.*
 
+## Leases
+
+![Manage Leases](/images/screenshots/manage-leases.png)
+
+**Leases do not automatically expire. Leases need to be updated manually.**
+
+To manage leases, go to `repository-url/leases`
+
+The Manage Leases page contains three tabs:
+- All Active Leases: Works where leases are current
+- Expired Active Leases: Works where leases are expired but they are still available and access status has not been changed
+- Deactivated Leases: Works that are out of lease and access status has been changed
+
+To deactivate leases:
+- Click the “Expired Active Leases” tab
+- Select works to release (optionally leave all files in lease state by unchecking the box “Change all files within work _ to _ status _ )
+- Click button “Deactivate Leases for Selected” or deactivate individually.
+
+## Embargoes
+
 ![Manage Embargoes](/images/screenshots/manage-embargoes.png)
+
+**Embargoes do not automatically expire. Embargoes need to be updated and deactivated manually.**
 
 To manage embargoes, go to `repository-url/embargoes`
 
@@ -26,17 +48,3 @@ To deactivate embargoes:
 - Click the “Expired Active Embargoes” tab
 - Select works to release (optionally leave all files in embargo state by unchecking the box “Change all files within work __ to _ status _ )
 - Click button “Deactivate Embargoes for Selected” or deactivate individually
-
-![Manage Leases](/images/screenshots/manage-leases.png)
-
-To manage embargoes, go to `repository-url/leases`
-
-The Manage Leases page contains three tabs:
-- All Active Leases: Works where leases are current
-- Expired Active Leases: Works where leases are expired but they are still available and access status has not been changed
-- Deactivated Leases: Works that are out of lease and access status has been changed
-
-To deactivate leases:
-- Click the “Expired Active Leases” tab
-- Select works to release (optionally leave all files in lease state by unchecking the box “Change all files within work _ to _ status _ )
-- Click button “Deactivate Leases for Selected” or deactivate individually.


### PR DESCRIPTION
This commit updates the lease-embargoes page in the manager guide. I have re-ordered the page so that Lease documentation is listed first, and have added important language about how leases and embargoes need to be managed manually.