### PR TITLE
Link the Communication page into the menu

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -62,6 +62,10 @@ entries:
   - title: Developer Community
     output: web, pdf
     folderitems:
+      
+    - title: Communication
+      url: /communication.html
+      output: web, pdf
 
     - title: Real Life Hyrax
       url: /real-life-hyrax.html

--- a/pages/samvera/developer_community/communication.md
+++ b/pages/samvera/developer_community/communication.md
@@ -3,9 +3,9 @@ title: Communication
 a-z: [Communication]
 last_updated: March 30, 2017
 tags: [getting_started, community]
-sidebar: samvera_sidebar
+sidebar: home_sidebar
 permalink: communication.html
-folder: samvera
+folder: samvera/community/
 ---
 # Communication
 


### PR DESCRIPTION
We had a page called "Communication" that wasn't linked from the menu. This PR fixes that.