### PR TITLE
Promotion and Deprecation

### DIFF
--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -62,9 +62,13 @@ entries:
   - title: Developer Community
     output: web, pdf
     folderitems:
+      
+    - title: Communication
+      url: /communication.html
+      output: web, pdf
 
-    - title: Real Life Hyrax
-      url: /real-life-hyrax.html
+    - title: Contribution Tools
+      url: /contribution-tools.html
       output: web, pdf
 
       subfolders:
@@ -79,12 +83,24 @@ entries:
         - title: Release Testing
           url: /release_testing.html
           output: web, pdf
+          
+      - title: Labs, Core, and Deprecation
+        output: web, pdf
+        subfolderitems:
 
-    - title: Contribution Tools
-      url: /contribution-tools.html
-      output: web, pdf
+        - title: Samvera Labs
+          url: /samvera_labs.html
+          output: web, pdf
 
-    - title: How to Submit Pull Reqeusts
+        - title: Core Components
+          url: /core_components.html
+          output: web, pdf
+          
+        - title: Deprecation
+          url: /deprecation.html
+          output: web, pdf
+
+    - title: How to Submit Pull Requests
       url: /how-to-pr.html
       output: web, pdf
 

--- a/pages/samvera/developer_community/core_components.md
+++ b/pages/samvera/developer_community/core_components.md
@@ -1,0 +1,22 @@
+---
+title: Core Samvera Code Repository
+a-z: [Core Components, Github, Maintenance]
+last_updated: February 26, 2018
+tags: [labs, community, development, maintenance]
+sidebar: samvera_sidebar
+permalink: core_components.html
+folder: samvera
+toc: true
+---
+# Samvera Code Repository
+
+The [primary Samvera code repository](https://github.com/samvera) contains the 
+Samvera community's current consensus 
+on what we are using, maintaining, and recommending. Ideally, this repository 
+only contains code modules that are being actively used and maintained. Anything 
+that falls into disuse should be a candidate for [deprecation](deprecation.html). 
+
+## Maintenance
+
+The Core Components Working Group is in the process of creating a framework for 
+addressing ongoing maintenance of shared code repositories. 

--- a/pages/samvera/developer_community/deprecation.md
+++ b/pages/samvera/developer_community/deprecation.md
@@ -1,0 +1,55 @@
+---
+title: Deprecation
+a-z: [Core Components, Github, Maintenance, Deprecation]
+last_updated: February 26, 2018
+tags: [labs, community, development, maintenance, deprecation]
+sidebar: samvera_sidebar
+permalink: deprecation.html
+folder: samvera
+toc: true
+---
+# Deprecation
+
+The [`samvera-deprecated` github organization](https://github.com/samvera-deprecated) is the place for older gems, apps, and 
+experiments that we no longer recommend deploying in production but that may be 
+useful for sample code or reference. This also might be where legacy code that 
+some organizations still use is kept, if it no longer meets criteria for community
+maintenance or is no longer recommended for new adoption. 
+
+Just because a code repository has been deprecated does not mean it can't have
+new development or new releases. It just means that we as a community cannot 
+commit to maintaining it and can't recommend it for new production use. 
+
+## Deprecation process from core
+
+If a code repository in the core Samvera github:
+
+1. no longer has three institutions using it 
+
+1. cannot be upgraded (which might mean no one is willing to upgrade it) to current 
+versions of core libraries
+
+1. is not recommended for production use for some other reason
+
+... any member of the community may nominate it for deprecation. However, the Core 
+Components Maintenance WG takes particular responsibility for keeping an eye on 
+what should be deprecated. 
+
+The process looks a lot like the promotion process:
+
+1. Email the samvera-tech mailing list saying what code repository you think should
+be deprecated and why. Ask whether three institutions can commit to maintaining 
+it and addressing any concerns (e.g., any unaddressed security issues). Provide a 
+date, at least 30 days later, by which these responses should be received. 
+
+2. If that date has been reached and no agreement has been reached, the code can
+be moved to the samvera-deprecated organization. Please also send an email to all 
+Samvera lists documenting its move. 
+
+## Deprecation process from labs
+
+Not everything that starts off in Samvera-labs is destined for production use. 
+Deprecating a project from labs should follow the same pattern as deprecation 
+from core, except that three institutions are not required to commit to
+maintenance to keep something in labs. As long as someone is willing to take 
+ownership of the project it can stay in labs. 

--- a/pages/samvera/developer_community/samvera_labs.md
+++ b/pages/samvera/developer_community/samvera_labs.md
@@ -1,0 +1,77 @@
+---
+title: Samvera Labs
+a-z: [Labs, Samvera Labs, Starting a Project]
+last_updated: February 26, 2018
+tags: [labs, community, development]
+sidebar: samvera_sidebar
+permalink: samvera_labs.html
+folder: samvera
+toc: true
+---
+# What is Samvera-Labs?
+
+The [`samvera-labs` Github repository](https://github.com/samvera-labs) is for
+Samvera Experiments, Works-in-progress, and Beta versions of gems and apps. 
+Projects here may be suitable for production use, but awaiting broader adoption.
+
+## Requirements for creating a project
+The samvera-labs repository is meant to be a true lab, and experimentation is to 
+be encouraged as much as possible. The committers may accept any any contributions 
+to samvera-labs by any Samvera Licensed Contributors wishing to offer their work.
+
+## Guidelines for Promotion to Samvera from Labs
+To move from `samvera-labs` to the core `samvera` code organization, the following
+requirements must be met:
+
+### Code Requirements
+
+  1. Code must be released at version >= 1.0
+
+  1. Good unit test coverage measured by community (e.g. 100% or 75% of what’s important)
+
+  1. uses CI (Preferably Travis-CI, unless there is a compelling reason to do something else)
+
+  1. uses Coverage tool (coveralls or simplecov)
+  
+  1. Show compatibility with current Rails versions and other dependencies, when was it last tested; note compatibility with prior versions when available. Compatibility can be specified in the gemspec(s) or verified via CI matrix.
+  
+  1. [Hierarchy of promises](https://wiki.duraspace.org/display/samvera/Hydra+Stack+-+The+Hierarchy+of+Promises) asserted in clearly defined acceptance tests
+
+### Documentation Requirements
+
+  1. LICENSE file, Apache 2 (or compatible)
+
+  1. README.md
+
+  1. Statement of purpose
+
+  1. Basic install steps
+
+  1. Identify any volatile/experimental features
+
+  1. How to contribute -> CONTRIBUTING.md
+
+  1. How/Who to contact for help -> push out to all gems like CONTRIBUTING.md
+
+  1. Known issues documented in github Issues tickets (not just listed in text)
+
+  1. Tutorial / Walkthrough / Example usage
+
+  1. Resolve TODO items in documents and remove them
+  
+  1. All Contributors should have signed Hydra Contibutor License Agreement (CLA)
+
+### Use Requirements
+
+1. Community use by three or more institutions
+
+1. In active use for six months
+
+
+## Mechanism for Promotion
+
+As needed or requested, code repositories are reviewed for promotion / deprecation. 
+To start this process, email the Samvera Tech list with a request. Provide documentation
+that all of the above requirements have been met. Ask for a spot on the next developer's 
+call to discuss the issue. Once the promotion has been decided, another email 
+should go out to the list with an announcement. 


### PR DESCRIPTION
This PR represents a deliverable of the
Core Components WG, namely, to document
in a central location the process for promoting
a gem from labs to core, and for deprecating
a gem from core to samvera-deprecated. This
will eventually replace the out-of-date
page at samvera-labs.github.io.