### PR TITLE
Runs RSpec tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,12 @@
 language: ruby
-rvm:
-- 2.3.3
 
-before_script:
- - chmod +x ./script/cibuild # or do this locally and commit
- 
-exclude: [vendor]
-# Assume bundler is being used, therefore
-# the `install` step will run `bundle install` by default.
-script: ./script/cibuild
+rvm:
+- 2.4.3
+- 2.5.0
 
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+  - WAIT_FOR_JEKYLL=10
 
 sudo: false # route your build to the container-based infrastructure for a faster build

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
-# A placeholder while we work on getting Travis building the actual
-# Jekyll site. See PR https://github.com/samvera/samvera.github.io/pull/154
-task :default do
-  $stdout.puts "A placeholder task until https://github.com/samvera/samvera.github.io/pull/154 is resolved."
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task :default => :spec
+rescue LoadError
+  # no rspec available
 end

--- a/_config.yml
+++ b/_config.yml
@@ -25,9 +25,13 @@ host: 127.0.0.1
 port: 4000
 # the port where the preview is rendered. You can leave this as is unless you have other Jekyll builds using this same port that might cause conflicts. in that case, use another port such as 4006.
 exclude:
-  - .idea/
-  - .gitignore
   - vendor
+  - spec
+  - README.md
+  - Rakefile
+  - update.sh
+  - Gemfile*
+  - CONTRBUTING.md
 # these are the files and directories that jekyll will exclude from the build
 
 feedback_subject_line: Jekyll documentation theme

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e # halt script on error
-
-bundle exec jekyll build
-#bundle exec htmlproofer ./_site

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -120,13 +120,15 @@ RSpec.configure do |config|
     Capybara.app = Rack::Jekyll.new(force_build: true)
 
     # Sleep a while to let the site build. Tell the user what you're doing.
-    @wait_for = 5
-    puts "\nWaiting #{@wait_for} seconds for the site to build.\n\n"
-    @wait_for.times { sleep 1 }
+    @wait_for_jekyll = ENV['WAIT_FOR_JEKYLL'].to_i || 5
+    puts "\nWaiting #{@wait_for_jekyll} seconds for the site to build.\n\n"
+    @wait_for_jekyll.times { sleep 1 }
+
+    # Run HTMLProofer
+    # require 'html-proofer'
+    # puts "\nRunning HTML Proofer....\n"
+    # HTMLProofer.check_directory("./_site", allow_hash_href: true).run
   end
 
-  # config.after :suite do
-  #   capybara_temp_file_regex = /capybara\-\d+\.html/
-  #   Dir()
-  # end
+  config.default_formatter = 'doc'
 end

--- a/test.md
+++ b/test.md
@@ -1,4 +1,0 @@
----
-layout: default
-title:  Samvera Community Training'
----


### PR DESCRIPTION
* Sets default rake task to run RSpec tests.
* Sets RSpec formatter to be 'documentation'.
* Removes unneeded script for building the site.
* Removes unneeded test.md from project root.
* Uses env var `WAIT_FOR_JEKYLL` for how long to allow Jekyll to build site.
* Adds several more files to exclude from the build; removes hidden files which
  need not be listed, they are excluded by default.
* Removes `exclude` from `.travis.yml`; it only needs to be in `_config.yml`.