### PR TITLE
Add link to config/features.rb which defines flipper keys and defaults

### DIFF
--- a/pages/samvera/developer_resources/toggle-features.md
+++ b/pages/samvera/developer_resources/toggle-features.md
@@ -20,6 +20,8 @@ proxy_deposit:
   enabled: false
 ```
 
-If both options exist, whichever option is set from the Administrative Dashboard will take precedence.
+For a list of flipper features that can be configured in this way, see the [https://github.com/samvera/hyrax/blob/master/config/features.rb](https://github.com/samvera/hyrax/blob/master/config/features.rb) which defines keys and whether they are enabled by default.
 
-[Here is the list of all the features](https://github.com/samvera/hyrax/wiki/Feature-matrix) available to your Hyrax application, with instructions on how to configure them.
+<ul class='warning'><li>If both options exist, whichever option is set from the Administrative Dashboard will take precedence.</li></ul>
+
+For a complete list of features and instructions on how to configure them, see the [Hyrax Feature-matrix](https://github.com/samvera/hyrax/wiki/Feature-matrix).


### PR DESCRIPTION
I was looking around for doc on how to set a flipper in code instead of through the UI and found this page.  THANKS!!!

I needed additional information to know all the possible settings.  So I updated the page to include a link to the defaults in hyrax.

Since any changes made through the UI override changes made through the configuration, it would good to have instructions on how to reset to defaults.  I have a pending question in slack dev about how to do that.  This PR shouldn't wait for that information to be made available.