### PR TITLE
Add links to community websites

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,14 @@ site_title: Samvera Community Knowledge Base
 company_name: Samvera Community
 # this appears in the footer
 
+organization_link: http://samvera.org/
+organization_link_name: samvera.org
+# this appears in the footer
+
+community_link: https://wiki.duraspace.org/display/samvera/Samvera
+community_link_name: Community Wiki
+# this appears in the footer
+
 # github_editme_path: tomjohnson1492/documentation-theme-jekyll/blob/gh-pages/
 # if you're using Github, provide the basepath to the branch you've created for reviews, following the sample here. if not, leave this value blank.
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,6 +3,8 @@
                 <div class="col-lg-12 footer">
                &copy;{{ site.time | date: "%Y"  }} {{site.company_name}}. All rights reserved. <br />
 {% if page.last_updated %}<span>Page last updated:</span> {{page.last_updated}}<br/>{% endif %} Site last generated: {{ site.time | date: "%b %-d, %Y"  }} <br />
+<a href="{{site.organization_link}}">{{site.organization_link_name}}</a><br />
+<a href="{{site.community_link}}">{{site.community_link_name}}</a></a><br />
 <p><img src="/images/company_logo.png" alt="Company logo"/></p>
                 </div>
             </div>

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -948,7 +948,7 @@ span.soft {
 }
 
 /* this part adds an icon after external links, using FontAwesome*/
-a[href^="http://"]:after, a[href^="https://"]:after {
+/* a[href^="http://"]:after, a[href^="https://"]:after {
     content: "\f08e";
     font-family: FontAwesome;
     font-weight: normal;
@@ -956,7 +956,7 @@ a[href^="http://"]:after, a[href^="https://"]:after {
     display: inline-block;
     text-decoration: none;
     padding-left: 3px;
-}
+} */
 
 /* Strip the outbound icon when this class is present */
 a[href].noCrossRef::after,


### PR DESCRIPTION
Fixes https://github.com/samvera/samvera.github.io/issues/279

Adds links to http://samvera.org and
https://wiki.duraspace.org/display/samvera/Samvera

Links will appear on footer of each page on the site.

![screen shot 2018-05-25 at 3 24 35 pm](https://user-images.githubusercontent.com/17851674/40562626-c7fa4d26-602f-11e8-9ba1-07b29fa257d7.png)
