### PR TITLE
Remove relative page links

### DIFF
--- a/_includes/google_search.html
+++ b/_includes/google_search.html
@@ -1,6 +1,5 @@
 <div id="search-demo-container">
-  <!-- this didn't work locally for me: form role="search" method="get" action="{{ site.baseurl }}//search/" -->
-  <form role="search" method="get" action="/search" id="search-input">
+  <form role="search" method="get" action="{{ site.url }}/search/" id="search-input">
       <input id="searchString" name="searchString"
        placeholder="Search..." type="text">
     <button type="submit" title="Search for keywords"><i class="fa fa-search" name="googleSearchName"value="Search"></i></button>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -11,11 +11,11 @@
             {% for folderitem in folder.folderitems %}
             {% if folderitem.output contains "web" %}
             {% if folderitem.external_url %}
-            <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+            <li><a href="{{ site.url }}/{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
             {% elsif page.url == folderitem.url %}
-            <li class="active"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+            <li class="active"><a href="{{ site.url }}/{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
             {% else %}
-            <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+            <li><a href="{{ site.url }}/{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
             {% endif %}
             {% for subfolders in folderitem.subfolders %}
             {% if subfolders.output contains "web" %}
@@ -25,11 +25,11 @@
                     {% for subfolderitem in subfolders.subfolderitems %}
                     {% if subfolderitem.output contains "web" %}
                     {% if subfolderitem.external_url %}
-                    <li><a href="{{subfolderitem.external_url}}" target="_blank">{{subfolderitem.title}}</a></li>
+                    <li><a href="{{ site.url }}/{{subfolderitem.external_url}}" target="_blank">{{subfolderitem.title}}</a></li>
                     {% elsif page.url == subfolderitem.url %}
-                    <li class="active"><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                    <li class="active"><a href="{{ site.url }}/{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
                     {% else %}
-                    <li><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                    <li><a href="{{ site.url }}/{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
                     {% endif %}
                     {% endif %}
                     {% endfor %}
@@ -50,10 +50,10 @@
            -->
     </li>
     <li>
-      <a href="glossary-2.1.html">Glossary</a>
+      <a href="{{ site.url }}/glossary-2.1.html">Glossary</a>
     </li>
     <li>
-      <a href="a-z.html">A-Z Index</a>
+      <a href="{{ site.url }}/a-z.html">A-Z Index</a>
     </li>
 </ul>
 </div>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -8,7 +8,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="fa fa-home fa-lg navbar-brand" href="index.html">&nbsp;<span class="projectTitle"> {{site.topnav_title}}</span></a>
+            <a class="fa fa-home fa-lg navbar-brand" href="{{ site.url }}/index.html">&nbsp;<span class="projectTitle"> {{site.topnav_title}}</span></a>
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Relative links were broken by the addition of google search, because it
added /search into all of the links. Prepend links with {{ site.url }}/
to correct this behavior.

Fixes #315 