### PR TITLE
Clean up versions

### DIFF
--- a/_includes/version_info/version_hyrax_1.0-stable.html
+++ b/_includes/version_info/version_hyrax_1.0-stable.html
@@ -1,3 +1,3 @@
-{% assign version_label = 'Hyrax stable v1.0' %}
+{% assign version_label = 'Hyrax v1.0' %}
 {% assign branch_label = '1.0-stable' %}
 {% assign branch_link = 'https://github.com/samvera/hyrax/tree/1-0-stable' %}

--- a/_includes/version_info/version_hyrax_2.0-master.html
+++ b/_includes/version_info/version_hyrax_2.0-master.html
@@ -1,3 +1,0 @@
-{% assign version_label = 'Hyrax master v2.0-alpha' %}
-{% assign branch_label = 'master' %}
-{% assign branch_link = 'https://github.com/samvera/hyrax/tree/master' %}

--- a/_includes/version_info/version_hyrax_2.0-stable.html
+++ b/_includes/version_info/version_hyrax_2.0-stable.html
@@ -1,0 +1,3 @@
+{% assign version_label = 'Hyrax v2.0' %}
+{% assign branch_label = '2.0-stable' %}
+{% assign branch_link = 'https://github.com/samvera/hyrax/tree/2-0-stable' %}

--- a/_includes/version_info/version_hyrax_2.1-stable.html
+++ b/_includes/version_info/version_hyrax_2.1-stable.html
@@ -1,0 +1,3 @@
+{% assign version_label = 'Hyrax v2.1' %}
+{% assign branch_label = '2.1-stable' %}
+{% assign branch_link = 'https://github.com/samvera/hyrax/tree/2.1-stable' %}

--- a/_includes/versions.html
+++ b/_includes/versions.html
@@ -1,8 +1,10 @@
 {% case page.version.id %}
 {% when 'hyrax_1.0-stable' %}
   {% include version_info/version_hyrax_1.0-stable.html %}
-{% when 'hyrax_2.0-master' %}
-  {% include version_info/version_hyrax_2.0-master.html %}
+{% when 'hyrax_2.0-stable' %}
+  {% include version_info/version_hyrax_2.0-stable.html %}
+{% when 'hyrax_2.1-stable' %}
+  {% include version_info/version_hyrax_2.1-stable.html %}
 {% else %}
   {% include version_info/version_custom.html %}
 {% endcase %}

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/admin-set-participants.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/admin-set-participants.md
@@ -8,10 +8,8 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ["Admin Sets - Participants", "Collections - Admin Set Participants"]
 version:
-  label: 'Hyrax v2.1.0 (also applies to Hyrax v2.0.x)'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
+  label: 'Hyrax v2.1 (also applies to Hyrax v2.0.x)'
 ---
 
 ### Impact on Admin Set Access

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/admin-sets-as-collections.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/admin-sets-as-collections.md
@@ -8,10 +8,8 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['FAQ - Admin Sets as Collections', 'Collections - Admin Set Collection Type']
 version:
-  label: 'Hyrax v2.1.0 (also applies to Hyrax v2.0.x)'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
+  label: 'Hyrax v2.1 (also applies to Hyrax v2.0.x)'
 ---
 
 ### Are Admin Sets a type of collection?
@@ -48,11 +46,10 @@ The Hyrax 2.0 behaviors for Admin Sets determine the settings.  Effectively, the
 | Basic: | <font color='red'>X</font> <font color='grey'>NESTABLE</font><br><font color='red'>X</font> <font color='grey'>MULTIPLE MEMBERSHIP</font><br><font color='red'>X</font> <font color='grey'>DISCOVERY</font><br><font color='green'>√</font> SHARING |
 | Advanced: | <font color='green'>√</font> REQUIRE MEMBERSHIP<br><font color='green'>√</font> WORKFLOW<br><font color='green'>√</font> VISIBILITY |
 
-### Why not just go ahead and switch Admin Sets to be a Collection Type? 
+### Why not just go ahead and switch Admin Sets to be a Collection Type?
 
 * Changes at this level to Admin Sets would require significant changes to existing sites.
 * There is a lot of work required to create the extended functionality for collections. Due to time limitations, that work was not part of the initial implementation.
 * There are outstanding questions about the functional split between Admin Sets and Collections and what it would mean for more than one collection type to have some of the advanced settings.
 
 Ultimately, there was a conscious choice to minimize churn for those already moving toward production with Hyrax using the current definition of Admin Sets.
-

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/collection-sharing.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/collection-sharing.md
@@ -8,10 +8,7 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['Collection Sharing', 'Sharing for Collections']
 version:
-  label: 'targeted for Hyrax v2.1.0'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
 ---
 
 ## How to set participants for a collection?
@@ -27,25 +24,25 @@ version:
 
 ### Manager
 
-Managers of a collection can add to and remove works from the collection, modify collection metadata, and delete the collection.  If the collection type allows nesting of collections, the manager can also add and remove parent collections and subcollections.  If configured to set work permissions, the managers are given 'edit_access' to any work created directly in the collection.  See [Configuring collection sharing](collection-type-participants.html#configuring-collection-sharing) for more information. 
+Managers of a collection can add to and remove works from the collection, modify collection metadata, and delete the collection.  If the collection type allows nesting of collections, the manager can also add and remove parent collections and subcollections.  If configured to set work permissions, the managers are given 'edit_access' to any work created directly in the collection.  See [Configuring collection sharing](collection-type-participants.html#configuring-collection-sharing) for more information.
 
 **Default:**  user creating the collection and Collection Type managers for this collection's type
 
 **Implementation:**
 
 * When a manager is added
-  * an entry is added to the database via `Hyrax::PermissionTemplateAccess` granting the user/group `:manage` access 
+  * an entry is added to the database via `Hyrax::PermissionTemplateAccess` granting the user/group `:manage` access
   * `edit_access_group_ssim` or `edit_access_person_ssim` is set in the solr document
   * a `Hydra::AccessControls::Permission` is added in Fedora
 * When a manager is removed
-  * the entry added by `Hyrax::PermissionTemplateAccess` is removed from the database for this manager 
+  * the entry added by `Hyrax::PermissionTemplateAccess` is removed from the database for this manager
   * `edit_access_group_ssim` or `edit_access_person_ssim` is updated to remove the group/user id from the solr document
   * the `Hydra::AccessControls::Permission` is removed from Fedora
 * When the create new work actor stack is run, if this is the only collection assigned, then the work is considered to be created directly in the collection.  When a work is created directly in a collection AND the collection type is configured to apply permissions to new works
   * each manager is granted `edit_access` to the new work
 
 <ul class='info'><li>A <b>work is considered to be created directly in a collection</b> when the work is first created, if-and-only-if, there is one collection assigned to the work when the work is saved for the first time.</li></ul>
-  
+
 Special Notes on Admin Sets:
 * A site can set managers on an admin set, which grants them `:manage` access to that admin set.  This creates the solr edit access and Fedora AccessControl entries as well, same as for other collections.
 * Admin set managers are given `edit_access` to a work at the time it is creating within the admin set.
@@ -56,7 +53,7 @@ Special Notes on Admin Sets:
 
 ### Depositor
 
-Depositors of a collection can view the collection's admin show page and add works even if the visibility permissions of the collection otherwise would not permit them to view it.  If the collection type allows nesting of collections, the manager can also add parent collections and subcollections. 
+Depositors of a collection can view the collection's admin show page and add works even if the visibility permissions of the collection otherwise would not permit them to view it.  If the collection type allows nesting of collections, the manager can also add parent collections and subcollections.
 
 **Default:**  *assigned only, no defaults*
 
@@ -65,7 +62,7 @@ Depositors of a collection can view the collection's admin show page and add wor
 * When a depositor is added
   * an entry is added to the database via `Hyrax::PermissionTemplateAccess` granting the user/group `:deposit` access
 * When a depositor is removed
-  * the entry added by `Hyrax::PermissionTemplateAccess` is removed from the database for this depositor 
+  * the entry added by `Hyrax::PermissionTemplateAccess` is removed from the database for this depositor
 * When the create new work actor stack is run, no special access is granted to depositors.
 
 
@@ -78,11 +75,11 @@ Viewers of a collection can add to and remove works from the collection, modify 
 **Implementation:**
 
 * When a viewer is added
-  * an entry is added to the database via `Hyrax::PermissionTemplateAccess` granting the user/group `:view` access 
+  * an entry is added to the database via `Hyrax::PermissionTemplateAccess` granting the user/group `:view` access
   * `read_access_group_ssim` or `read_access_person_ssim` is set in the solr document
   * a `Hydra::AccessControls::Permission` is added in Fedora
 * When a viewer is removed
-  * the entry added by `Hyrax::PermissionTemplateAccess` is removed from the database for this viewer 
+  * the entry added by `Hyrax::PermissionTemplateAccess` is removed from the database for this viewer
   * `read_access_group_ssim` or `read_access_person_ssim` is updated to remove the group/user id from the solr document
   * the `Hydra::AccessControls::Permission` is removed from Fedora
 * When the create new work actor stack is run, if this is the only collection assigned, then the work is considered to be created directly in the collection.  When a work is created directly in a collection AND the collection type is configured to apply permissions to new works
@@ -102,24 +99,24 @@ Viewers of a collection can add to and remove works from the collection, modify 
 
 Works that are assigned access grants through a collection or admin set are not updated if the roles in the collection or admin set are changed after the work already exists.  
 
-For example, 
-* if user-1 is a manager of collection-1 when work-1 is created 
+For example,
+* if user-1 is a manager of collection-1 when work-1 is created
   * user-1 is granted `edit_access` to work-1
 * if collection-1 participants is changed to remove user-1 as a manager and add user-2 as a manager
   * work-1 continues to have user-1 with `edit_access`  
   * user-2 has no special access grants to work-1  
-* when work-2 is created after the manager change 
+* when work-2 is created after the manager change
   * user-2 is granted `edit_access` to work-2, and all other works going forward as long as user-2 is a manager of the collection/admin_set
 
 ### Why might you want to set user participants?
 
 Some sites have preservation concerns and do not want to allow access roles to change on existing collections and works.  In this case, you may want to set participants as specific users.  Any changes to existing collections and works will require an edit of each one individually to change those assigned to roles.
- 
+
 ### What are the benefits of setting groups as participants?
 
 If you set a group as a participant, you are granting access to all members of that group.  You can move users in and out of the group to grant or remove access to a work.
 
-For example, 
+For example,
 * if group-1 includes user-1 AND group-1 is a manager of collection-1 when work-1 is created
   * group-1 is granted `edit_access` to work-1
   * user-1 has `edit_access` to work-1 through their membership in group-1

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/collection-type-participants.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/collection-type-participants.md
@@ -8,10 +8,7 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['Collection Type Participants', 'Participants for Collection Types']
 version:
-  label: 'targeted for Hyrax v2.1.0'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
 ---
 
 NOTE: Only admins can create, edit, and delete collection types.  Participants set for a collection type effect how users can interact with collections of this type.
@@ -29,7 +26,7 @@ NOTE: Only admins can create, edit, and delete collection types.  Participants s
 
 ### Manager
 
-**Description:** 
+**Description:**
 
 Managers for a collection type can edit collections other users created, including adding to and removing works from a collection, modifying collection metadata, and deleting collections, only for collections of the type they manage.
 
@@ -41,7 +38,7 @@ Managers for a collection type can edit collections other users created, includi
 * When a manager is removed, the entry added by `Hyrax::CollectionTypeParticipant` is removed from the database for this manager.
 * When the create new collection process is initiated, the user is allowed to create collections of types for which they have manage access.
 * When a collection is created of a type, each collection type manager is made a manager of the collection which grants them `edit_access` to the new collection regardless of which user creates the collection.  This `edit_access` grant is what grants managers the abilities to edit the collection, collection items, and metadata.
-  
+
 **Special Note on Admin Sets:**
 * Admin Set collection type is pre-defined and has default managers assigned.
 * **Default:**  Repository Administrators
@@ -51,7 +48,7 @@ Managers for a collection type can edit collections other users created, includi
 
 ### Creator
 
-**Description:** 
+**Description:**
 
 Creators for a collection type can create collections of this type.  They are given manage access only to collections they create.
 

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/collection-types.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/collection-types.md
@@ -8,10 +8,8 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['Collection Types']
 version:
-  label: 'Hyrax v2.1.0 (also applies to Hyrax v2.0.x)'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
+  label: 'Hyrax v2.1 (also applies to Hyrax v2.0.x)'
 ---
 
 ## Understanding Collection Types
@@ -30,7 +28,7 @@ An administrative grouping of works that an administrative unit is ultimately re
 
 **User Collections** (preconfigured)
 
-An intellectual grouping of works, primarily used by individual users to create groups of items or favorites. 
+An intellectual grouping of works, primarily used by individual users to create groups of items or favorites.
 
 **Exhibits**
 
@@ -40,7 +38,7 @@ A grouping of existing works into an exhibit oriented toward display of content 
 
 Provide the ability to nest collections for the purpose of organizing content.  Several use cases fall into this category and have significant overlap of requirements.  These include DSpace migrated content (i.e. Community → Collection), organization unit based collections (e.g. University → School → Department; Agency → Sub-agency; etc.), and general nesting for organizing materials.  
 
- 
+
 Don’t see your use case?  That’s ok, because Collection Types allow you to define and configure your own type.
 
 ### Configuring a Collection Type
@@ -89,9 +87,9 @@ The process for defining and configuring a collection type is quite simple.  Not
 
 **Step 2:  Set type name, type description, and click Save**  
 
-Note: 
+Note:
 * Users will see the type name and description when selecting a type of collection to create.  The information provided should help them decide the appropriate collection type to create.
-* The collection type name be used in filters and as a collection type badge in a number of places in the UI.  It is generally best to keep the collection type name short. 
+* The collection type name be used in filters and as a collection type badge in a number of places in the UI.  It is generally best to keep the collection type name short.
 
 **Step 3:  Define configuration settings**
 
@@ -137,7 +135,7 @@ Self-deposit site vs. Curated site...
 
 Exhibits
 * You may want to choose to apply share permissions to works if works are created as the exhibit collections are being built.
-* You may want to choose NOT to apply share permissions to works if the exhibit collections are mostly built from existing works. 
+* You may want to choose NOT to apply share permissions to works if the exhibit collections are mostly built from existing works.
 
 NOTE:  Your site may define User Collections and Exhibits different than what is presented here.
 
@@ -159,10 +157,10 @@ The short answer is NO.  But if you are asking this, then presumably you want to
 
 Here are some strategies.
 
-* If your application is new and you do not have any collections being migrated from Hyrax 2.0 or earlier, then you can 
+* If your application is new and you do not have any collections being migrated from Hyrax 2.0 or earlier, then you can
   * change the name of the preconfigured User Collection to UNUSED and remove all participants from the creator role (you can use something like rails console to delete it)
-  * create a new type called User Collection, which you can configure to meet you needs 
+  * create a new type called User Collection, which you can configure to meet you needs
 
-* If you migrated collections from Hyrax 2.0, you could 
+* If you migrated collections from Hyrax 2.0, you could
   * rename User collection to something like Legacy User Collection.  Migrated user collections will have this type.
-  * create a new type called User Collection, which you can configure to meet you needs.  New user collection will have this type. 
+  * create a new type called User Collection, which you can configure to meet you needs.  New user collection will have this type.

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/discovery-faq.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/discovery-faq.md
@@ -8,10 +8,7 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['FAQ - Collection Discovery', 'Collections - Discovery', 'Discovery of Collections']
 version:
-  label: 'targeted for Hyrax v2.1.0'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
 ---
 
 ### What does it mean for a collection to be discoverable?

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/metadata-faq.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/metadata-faq.md
@@ -8,10 +8,8 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['FAQ - Collection Metadata', 'Collections - Metadata', 'Metadata for Collections']
 version:
-  label: 'Hyrax v2.1.0 (also applies to Hyrax v2.0.x)'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
+  label: 'Hyrax v2.1 (also applies to Hyrax v2.0.x)'
 ---
 
 ### What metadata is included in collections by default?

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/nested-indexing.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/nested-indexing.md
@@ -8,10 +8,7 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['Nested Indexing', 'Collections - Indexing']
 version:
-  label: 'targeted for Hyrax v2.1.0'
-  branch:
-    label: 'master'
-    link: 'https://github.com/samvera/hyrax'
+  id: hyrax_2.1-stable
 ---
 
 ### Collections In Fedora and Solr

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/nesting-faq.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/nesting-faq.md
@@ -8,10 +8,7 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['FAQ - Collection Nesting', 'Collections - Nesting', 'Nesting of Collections']
 version:
-  label: 'targeted for Hyrax v2.1.0'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
 ---
 
 ### What is collection nesting?
@@ -32,7 +29,7 @@ Yes.  A collection can have all sub-collections, all works, or a combination of 
 
 ### Is there a limit to how deep the nesting can go?
 
-The depth of nesting is limited. By default the limit is set to 5.  It is defined in the hyrax engine in `config/initializers/samvera-nesting_indexer_initializer.rb` by config `config.maximum_nesting_depth = 5`.  You can override this to set a different maximum_nesting_depth. 
+The depth of nesting is limited. By default the limit is set to 5.  It is defined in the hyrax engine in `config/initializers/samvera-nesting_indexer_initializer.rb` by config `config.maximum_nesting_depth = 5`.  You can override this to set a different maximum_nesting_depth.
 
 ### Can a collection be its own descendant?
 
@@ -58,7 +55,7 @@ Right now, there are two place to see nesting relationships and in both places, 
 * Collection show page at Dashboard -> Collections -> click title of collection
 * Collection edit form at Dashboard -> Collections -> click action menu beside collection -> Edit collection -> Relationship tab
 
-We hope to update the Dashboard -> Collections index page in later releases to include the ability to view nesting hierarchies, but there is extensive UI/UX design work required before implementation can happen. 
+We hope to update the Dashboard -> Collections index page in later releases to include the ability to view nesting hierarchies, but there is extensive UI/UX design work required before implementation can happen.
 
 ### Can admin sets be nested?
 

--- a/pages/samvera/developer_resources/collections/hyrax_2.1/overview.md
+++ b/pages/samvera/developer_resources/collections/hyrax_2.1/overview.md
@@ -8,10 +8,8 @@ sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['Collections Overview', 'Overview of Collections']
 version:
-  label: 'Hyrax v2.1.0 (also applies to Hyrax v2.0.x)'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
+  label: 'Hyrax v2.1 (also applies to Hyrax v2.0.x)'
 ---
 
 ## History
@@ -51,7 +49,7 @@ There is an additional option that allows the same permissions to be granted on 
 
 ### Discovery
 
-The discovery setting controls which collection types allow collections to be discoverable by the public and which do not.  See [Collection Discovery FAQ](collection-discovery-faq.html) for more information. 
+The discovery setting controls which collection types allow collections to be discoverable by the public and which do not.  See [Collection Discovery FAQ](collection-discovery-faq.html) for more information.
 
 ### Multiple Membership
 

--- a/pages/samvera/developer_resources/what_happens_when/hyrax_2.0/what-happens-deposit.md
+++ b/pages/samvera/developer_resources/what_happens_when/hyrax_2.0/what-happens-deposit.md
@@ -8,8 +8,8 @@ folder: samvera/how-to/what_happens_when/hyrax_2.0/what-happens-deposit.md
 sidebar: home_sidebar
 tags: [development_resources]
 a-z: ['What Happens When I Deposit Something? (Hyrax 2.0)', 'Deposit Work Process (Hyrax 2.0)', 'Save Work (Hyrax 2.0)', 'Actor Stack for Work (Hyrax 2.0)']
-version: 
-  id: 'hyrax_2.0-master'
+version:
+  id: 'hyrax_2.0-stable'
   versions:  
     - label: 'Hyrax 1.0'
       link:  'what-happens-deposit-1.0.html'

--- a/pages/samvera/glossary/hyrax_2.1/glossary.md
+++ b/pages/samvera/glossary/hyrax_2.1/glossary.md
@@ -9,17 +9,15 @@ sidebar: home_sidebar
 tags: [development_resources]
 toc: false
 version:
-  label: 'Hyrax v2.1.0 (also applies to Hyrax v2.0.x)'
-  branch:
-    label: 'collections-sprint'
-    link: 'https://github.com/samvera/hyrax/tree/collections-sprint'
+  id: hyrax_2.1-stable
+  label: 'Hyrax v2.1 (also applies to Hyrax v2.0.x)'
 ---
 
 ## Administrative Set
 An Administrative Set is a top-level grouping of Works that is managed by a user with administrative privileges, such as reviewing deposited Works before they are made accessible. Unlike Collections, Administrative Sets are not discoverable by searching or browsing the catalog. They are intended to provide repository administrators the ability to apply a workflow, define behaviors, and apply policies on a set of works. Only repository administrators can create an administrative set, but they can designate any user to have management or edit access to an administrative set. All works must belong to one, and only, one Admin Set. Example: Electronic Dissertations and Theses. ([more information...](admin-sets-as-collections-faq.html))
 
 ## Collection
-A thematic grouping of works or collections. Any user in the system can create a Collection. Collections can be visible publicly or kept private. Collections can have a dedicated thumbnail and be shared among repository users with defined access levels: view/download or edit. Only users with access to a collection can add Works to it. Example: Professor creates a collection of Works related to her funded research project. ([more information...](collection-overview.html)) 
+A thematic grouping of works or collections. Any user in the system can create a Collection. Collections can be visible publicly or kept private. Collections can have a dedicated thumbnail and be shared among repository users with defined access levels: view/download or edit. Only users with access to a collection can add Works to it. Example: Professor creates a collection of Works related to her funded research project. ([more information...](collection-overview.html))
 
 ## Collection Type
 Collection Types provide a means for configuring behavior of collections within a site.  The functionality that can be switched on/off are [nesting](collection-nesting-faq.html), [sharing](collection-sharing.html), [discovery](collection-discovery-faq.html), multiple-membership, and branding.  Once collections of a type have been created, these configurations can no longer be changed.  A site may want to create several collection types (e.g. exhibits and user collections).  ([more information...](collection-types.html))
@@ -48,7 +46,7 @@ A template that defines the Participants for Collection based on it's Collection
 
 ## Mediated Deposit Workflow
 The group of steps necessary for reviewing an ingested item and its metadata, culminating in approval before publishing it for public viewing.  ([more information...](https://github.com/samvera/sufia/wiki/Mediated-Deposit-Workflow))
- 
+
 ## Proxy
 A user who can deposit works on behalf of another user. Example. Research Assistant deposits articles written by a Professor.
 

--- a/pages/samvera/manager_guide/hyrax_1.0/batch-works-1.0.md
+++ b/pages/samvera/manager_guide/hyrax_1.0/batch-works-1.0.md
@@ -11,10 +11,10 @@ version:
   id: 'hyrax_1.0-stable'
   versions:
   - label: 'Hyrax 1.0'
-    link:  'collections-1.0.html'
+    link:  'batch-works-1.0.html'
     selected: 'true'
   - label: 'Hyrax 2.0'
-    link:  'collections-2.0.html'
+    link:  'batch-works-2.0.html'
 ---
 
 *This Guide is maintained by Samvera's [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group). Screenshots are taken from [Nurax](https://nurax.curationexperts.com/), a testing repository running on the latest release of Hyrax. Hosting is generously provided by [Data Curation Experts](https://curationexperts.com/). Please open an issue on our [GitHub repository](https://github.com/samvera/samvera.github.io) to request edits or additions.*

--- a/pages/samvera/manager_guide/hyrax_2.0/admin-sets-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/admin-sets-2.0.md
@@ -8,13 +8,7 @@ keywords: Best Practices, managers, repo mangers, hyrax administration
 tags: [user_resources]
 categories: How to use the Administration panel in hyrax
 version:
-  id: 'hyrax_2.0-master'
-  versions:  
-    - label: 'Hyrax 1.0'
-      link:  'admin-sets-1.0.html'
-    - label: 'Hyrax 2.0'
-      link:  'admin-sets-2.0.html'
-      selected: 'true'
+  id: 'hyrax_2.0-stable'
 ---
 
 *This Guide is maintained by Samvera's [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group). Screenshots are taken from [Nurax](https://nurax.curationexperts.com/), a testing repository running on the latest release of Hyrax. Hosting is generously provided by [Data Curation Experts](https://curationexperts.com/). Please open an issue on our [GitHub repository](https://github.com/samvera/samvera.github.io) to request edits or additions.*

--- a/pages/samvera/manager_guide/hyrax_2.0/batch-works-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/batch-works-2.0.md
@@ -8,7 +8,7 @@ keywords: Best Practices, managers, repo mangers, hyrax administration
 tags: [user_resources]
 categories: How to use the Administration panel in hyrax
 version:
-  id: 'hyrax_2.0-master'
+  id: 'hyrax_2.0-stable'
   versions:
   - label: 'Hyrax 1.0'
     link:  'batch-works-1.0.html'

--- a/pages/samvera/manager_guide/hyrax_2.0/collections-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/collections-2.0.md
@@ -8,13 +8,7 @@ keywords: Best Practices, managers, repo mangers, hyrax administration
 tags: [user_resources]
 categories: How to use the Administration panel in hyrax
 version:
-  id: 'hyrax_2.0-master'
-  versions:  
-  - label: 'Hyrax 1.0'
-    link:  'collections-1.0.html'
-  - label: 'Hyrax 2.0'
-    link:  'collections-2.0.html'
-    selected: 'true'
+  id: 'hyrax_2.0-stable'
 ---
 
 *This Guide is maintained by Samvera's [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group). Screenshots are taken from [Nurax](https://nurax.curationexperts.com/), a testing repository running on the latest release of Hyrax. Hosting is generously provided by [Data Curation Experts](https://curationexperts.com/). Please open an issue on our [GitHub repository](https://github.com/samvera/samvera.github.io) to request edits or additions.*

--- a/pages/samvera/manager_guide/hyrax_2.0/concepts-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/concepts-2.0.md
@@ -8,7 +8,7 @@ keywords: hyrax administration, glossary
 tags: [user_resources]
 categories:
 version:
-  id: 'hyrax_2.0-master'
+  id: 'hyrax_2.0-stable'
   versions:  
   - label: 'Hyrax 1.0'
     link:  'concepts-1.0.html'

--- a/pages/samvera/manager_guide/hyrax_2.0/configuration.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/configuration.md
@@ -8,7 +8,7 @@ keywords: Best Practices, managers, repo mangers, hyrax administration
 tags: [user_resources]
 categories: Configuration
 version:
-  id: 'hyrax_2.0-master'
+  id: 'hyrax_2.0-stable'
 ---
 
 *This Guide is maintained by Samvera's [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group). Screenshots are taken from [Nurax](https://nurax.curationexperts.com/), a testing repository running on the latest release of Hyrax. Hosting is generously provided by [Data Curation Experts](https://curationexperts.com/). Please open an issue on our [GitHub repository](https://github.com/samvera/samvera.github.io) to request edits or additions.*

--- a/pages/samvera/manager_guide/hyrax_2.0/create-works-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/create-works-2.0.md
@@ -8,7 +8,7 @@ keywords: Best Practices, managers, repo mangers, hyrax administration
 tags: [user_resources]
 categories: How to use the Administration panel in hyrax
 version:
-  id: 'hyrax_2.0-master'
+  id: 'hyrax_2.0-stable'
   versions:  
   - label: 'Hyrax 1.0'
     link:  'create-works-1.0.html'

--- a/pages/samvera/manager_guide/hyrax_2.0/edit-works-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/edit-works-2.0.md
@@ -8,7 +8,7 @@ keywords: Best Practices, managers, repo mangers, hyrax administration
 tags: [user_resources]
 categories: How to use the Administration panel in hyrax
 version:
-  id: 'hyrax_2.0-master'
+  id: 'hyrax_2.0-stable'
   versions:  
     - label: 'Hyrax 1.0'
       link:  'edit-works-1.0.html'

--- a/pages/samvera/manager_guide/hyrax_2.0/lease-embargoes-2.0.md
+++ b/pages/samvera/manager_guide/hyrax_2.0/lease-embargoes-2.0.md
@@ -8,7 +8,7 @@ keywords: Embargoes, Leases
 tags: [user_resources]
 categories: Managing Leases and Embargoes
 version:
-  id: 'hyrax_2.0-master'
+  id: 'hyrax_2.0-stable'
 ---
 
 *This Guide is maintained by Samvera's [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group). Screenshots are taken from [Nurax](https://nurax.curationexperts.com/), a testing repository running on the latest release of Hyrax. Hosting is generously provided by [Data Curation Experts](https://curationexperts.com/). Please open an issue on our [GitHub repository](https://github.com/samvera/samvera.github.io) to request edits or additions.*

--- a/pages/samvera/manager_guide/whats-new.md
+++ b/pages/samvera/manager_guide/whats-new.md
@@ -8,7 +8,7 @@ keywords: Hyrax, Samvera, Manager Guide
 tags: [user_resources]
 categories: What's New
 version:
-  id: 'hyrax_2.0-master'
+  id: 'hyrax_2.0-stable'
 ---
 
 # What's New in Hyrax 2?


### PR DESCRIPTION
Modify for release of Hyrax 2.1.
Refer all versions to stable branches, rather than master.
Remove bad version links in files where there is only one version.

Fixes https://github.com/samvera/samvera.github.io/issues/201

