### PR TITLE
step to update hyrax feature matrix wiki article that is no longer in code repo readme

### DIFF
--- a/pages/samvera/developer_community/release_process.md
+++ b/pages/samvera/developer_community/release_process.md
@@ -63,6 +63,8 @@ This testing process complements test coverage and regression testing in the cod
 
 - Make sure to update the README if the release requires any new system dependencies or startup steps.
 
+- Update the [Hyrax Feature Matrix](https://github.com/samvera/hyrax/wiki/Feature-matrix)
+
 - Final Release is announced widely
 
 ### Minor release process:


### PR DESCRIPTION
small injected list item in release process based on slack chats with @no-reply and friends. based off issue raised by Susan B. in slack general channel that discovered issue with [feature matrix](https://github.com/samvera/hyrax/wiki/Feature-matrix) not being updated per release and a suggestion that a `Since:` column be added.

🚲 🏠 

### Be sure to include the A-Z Index page if it has been updated

```
bundle exec jekyll build
cp generated/a-z.md pages/
```
Then make sure that commit of pages/atoz.md is in this PR
