### PR TITLE
Ensure correct column width for overly long words.

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -181,6 +181,7 @@ table th[class*="col-"] {
 
 table td:first-child {
     width: 150px;
+    word-break: break-all;
     /*font-weight:bold;*/
 }
 


### PR DESCRIPTION
Ensure correct column width in case of overly long words.

### Be sure to include the A-Z Index page if it has been updated

```
bundle exec jekyll build
cp generated/a-z.md pages/
```
Then make sure that commit of pages/atoz.md is in this PR
