### PR TITLE
Implement active css class for explicitly coded sidebar folder

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -49,7 +49,11 @@
            </p>
            -->
     </li>
+    {% if page.url == "/glossary-2.1.html" %}
+    <li class="active">
+    {% else %}
     <li>
+    {% endif %}
       <a href="{{ site.url }}/glossary-2.1.html">Glossary</a>
     </li>
 </ul>


### PR DESCRIPTION
# Descriptive summary of request

The layout of the sidebar highlights active folders via <li class=active ... < /li>. This should be added when sidebar entries are being coded explicitly into _includes/sidebar.html.
# Existing

Explicitly coded entries in the sidebar are not wrapped within <li class=active ... < /li>.
# This PR

Explicitly codes entries in the sidebar are wrapped within <li class=active ... < /li> which implements the same highlighting when that folder is active.
# Related work
closes #348 
