### PR TITLE
Adds generated pages to revision

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -137,3 +137,5 @@ theme: jekyll-theme-minimal
 url: http://samvera.github.io
 gems:
   - jekyll-sitemap
+
+keep_files: [browse_pages.html]


### PR DESCRIPTION
This is because Github Pages won't run custom plugins for security reasons. Any pages
added by generators need to be done so locally, and then committed to the repo as
static pages. In this case, it's the browse_pages.html that is generated by the
BrowsePagesGenerator.