### PR TITLE
Adds a hook to copy generated pages into the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-_site/*
-!_site/browse_pages.html
+_site
 .sass-cache/
 generated/
 .DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -138,4 +138,4 @@ url: http://samvera.github.io
 gems:
   - jekyll-sitemap
 
-keep_files: [browse_pages.html]
+github_pages_save_generated_files: ['browse_pages.html']

--- a/_plugins/github_pages_helper.rb
+++ b/_plugins/github_pages_helper.rb
@@ -1,0 +1,40 @@
+class GithubPagesHelper
+  attr_reader :site
+  def initialize(site)
+    @site = site
+  end
+
+  def save_generated_files
+    site.config.fetch('github_pages_save_generated_files', []).each do |relative_path|
+      if changed?(relative_path)
+        FileUtils.cp generated_file_path(relative_path), source_file_path(relative_path)
+      end
+    end
+  end
+
+  private
+
+    def changed?(relative_path)
+      generated_file_contents(relative_path) != source_file_contents(relative_path)
+    end
+
+    def generated_file_contents(relative_path)
+      File.read generated_file_path(relative_path) if File.exists? generated_file_path(relative_path)
+    end
+
+    def source_file_contents(relative_path)
+      File.read source_file_path(relative_path) if File.exists? source_file_path(relative_path)
+    end
+
+    def generated_file_path(relative_path)
+      File.join(site.dest, relative_path)
+    end
+
+    def source_file_path(relative_path)
+      File.join(site.source, relative_path)
+    end
+end
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  GithubPagesHelper.new(site).save_generated_files
+end

--- a/browse_pages.html
+++ b/browse_pages.html
@@ -35,7 +35,7 @@
 <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
 <![endif]-->
 
-<link rel="alternate" type="application/rss+xml" title="" href="http://localhost:4000feed.xml">
+<link rel="alternate" type="application/rss+xml" title="" href="http://samvera.github.iofeed.xml">
 
     <script>
         $(document).ready(function() {
@@ -87,7 +87,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="fa fa-home fa-lg navbar-brand" href="http://localhost:4000/index.html">&nbsp;<span class="projectTitle"> Samvera Community Knowledge Base</span></a>
+            <a class="fa fa-home fa-lg navbar-brand" href="http://samvera.github.io/index.html">&nbsp;<span class="projectTitle"> Samvera Community Knowledge Base</span></a>
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
@@ -108,7 +108,7 @@
                 
               <li>
                 <div id="search-demo-container">
-  <form role="search" method="get" action="http://localhost:4000/search/" id="search-input">
+  <form role="search" method="get" action="http://samvera.github.io/search/" id="search-input">
       <input id="searchString" name="searchString"
        placeholder="Search..." type="text">
     <button type="submit" title="Search for keywords"><i class="fa fa-search" name="googleSearchName"value="Search"></i></button>
@@ -156,77 +156,77 @@
             
             
             
-            <li><a href="http://localhost:4000/introduction.html">Introduction</a></li>
+            <li><a href="http://samvera.github.io/introduction.html">Introduction</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/formalities.html">Formalities</a></li>
+            <li><a href="http://samvera.github.io/formalities.html">Formalities</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/getting_started.html">Up and Running</a></li>
+            <li><a href="http://samvera.github.io/getting_started.html">Up and Running</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/our_technology_stack.html">Our Technology Stack</a></li>
+            <li><a href="http://samvera.github.io/our_technology_stack.html">Our Technology Stack</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/get-help.html">How to Ask for Help</a></li>
+            <li><a href="http://samvera.github.io/get-help.html">How to Ask for Help</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/other-getting-started.html">Other Helpful Getting Started Docs</a></li>
+            <li><a href="http://samvera.github.io/other-getting-started.html">Other Helpful Getting Started Docs</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/deeper_samvera_index.html">Dive Deeper Into Samvera (Slideshow)</a></li>
+            <li><a href="http://samvera.github.io/deeper_samvera_index.html">Dive Deeper Into Samvera (Slideshow)</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/touring_samvera_index.html">Samvera Design Patterns (Slideshow)</a></li>
+            <li><a href="http://samvera.github.io/touring_samvera_index.html">Samvera Design Patterns (Slideshow)</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/hyku-vs-hyrax.html">Hyku vs Hyrax</a></li>
+            <li><a href="http://samvera.github.io/hyku-vs-hyrax.html">Hyku vs Hyrax</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/blacklight-plugins.html">Other Blacklight Plugins</a></li>
+            <li><a href="http://samvera.github.io/blacklight-plugins.html">Other Blacklight Plugins</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/training.html">Training</a></li>
+            <li><a href="http://samvera.github.io/training.html">Training</a></li>
             
             
             
@@ -241,7 +241,7 @@
             
             
             
-            <li><a href="http://localhost:4000/communication.html">Communication</a></li>
+            <li><a href="http://samvera.github.io/communication.html">Communication</a></li>
             
             
             
@@ -251,13 +251,13 @@
                     
                     
                     
-                    <li><a href="http://localhost:4000/release_process.html">Release Process</a></li>
+                    <li><a href="http://samvera.github.io/release_process.html">Release Process</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/release_testing.html">Release Testing</a></li>
+                    <li><a href="http://samvera.github.io/release_testing.html">Release Testing</a></li>
                     
                     
                     
@@ -272,19 +272,19 @@
                     
                     
                     
-                    <li><a href="http://localhost:4000/samvera_labs.html">Samvera Labs</a></li>
+                    <li><a href="http://samvera.github.io/samvera_labs.html">Samvera Labs</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/core_components.html">Core Components</a></li>
+                    <li><a href="http://samvera.github.io/core_components.html">Core Components</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/deprecation.html">Deprecation</a></li>
+                    <li><a href="http://samvera.github.io/deprecation.html">Deprecation</a></li>
                     
                     
                     
@@ -296,7 +296,7 @@
             
             
             
-            <li><a href="http://localhost:4000/how-to-pr.html">How to Submit Pull Requests</a></li>
+            <li><a href="http://samvera.github.io/how-to-pr.html">How to Submit Pull Requests</a></li>
             
             
             
@@ -311,42 +311,42 @@
             
             
             
-            <li><a href="http://localhost:4000/configuration-2.1.html">Configuring the Repository</a></li>
+            <li><a href="http://samvera.github.io/configuration-2.1.html">Configuring the Repository</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/create-works-2.1.html">Creating a Work</a></li>
+            <li><a href="http://samvera.github.io/create-works-2.1.html">Creating a Work</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/edit-works-2.1.html">Editing a Work</a></li>
+            <li><a href="http://samvera.github.io/edit-works-2.1.html">Editing a Work</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/collections-2.1.html">Collections</a></li>
+            <li><a href="http://samvera.github.io/collections-2.1.html">Collections</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/batch-ops-2.1.html">Batch Operations</a></li>
+            <li><a href="http://samvera.github.io/batch-ops-2.1.html">Batch Operations</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/lease-embargoes-2.1.html">Leases and Embargoes</a></li>
+            <li><a href="http://samvera.github.io/lease-embargoes-2.1.html">Leases and Embargoes</a></li>
             
             
             
@@ -361,7 +361,7 @@
             
             
             
-            <li><a href="http://localhost:4000/toggle-features.html">Enabling Features</a></li>
+            <li><a href="http://samvera.github.io/toggle-features.html">Enabling Features</a></li>
             
             
             
@@ -371,13 +371,13 @@
                     
                     
                     
-                    <li><a href="http://localhost:4000/patterns-overview.html">Overview</a></li>
+                    <li><a href="http://samvera.github.io/patterns-overview.html">Overview</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/patterns-presenters.html">Presenters</a></li>
+                    <li><a href="http://samvera.github.io/patterns-presenters.html">Presenters</a></li>
                     
                     
                     
@@ -389,7 +389,7 @@
             
             
             
-            <li><a href="http://localhost:4000/best-practices-coding-styles.html">Coding Style with RuboCop</a></li>
+            <li><a href="http://samvera.github.io/best-practices-coding-styles.html">Coding Style with RuboCop</a></li>
             
             
             
@@ -399,13 +399,13 @@
                     
                     
                     
-                    <li><a href="http://localhost:4000/what-happens-deposit-1.0.html">I Deposit Something (1.0)</a></li>
+                    <li><a href="http://samvera.github.io/what-happens-deposit-1.0.html">I Deposit Something (1.0)</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/what-happens-deposit-2.0.html">I Deposit Something (2.0)</a></li>
+                    <li><a href="http://samvera.github.io/what-happens-deposit-2.0.html">I Deposit Something (2.0)</a></li>
                     
                     
                     
@@ -420,13 +420,13 @@
                     
                     
                     
-                    <li><a href="http://localhost:4000/groups.html">Default Setup</a></li>
+                    <li><a href="http://samvera.github.io/groups.html">Default Setup</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/admin-users.html">Database-backed Setup</a></li>
+                    <li><a href="http://samvera.github.io/admin-users.html">Database-backed Setup</a></li>
                     
                     
                     
@@ -438,7 +438,7 @@
             
             
             
-            <li><a href="http://localhost:4000/actor_stack.html">Working with the Actor Stack</a></li>
+            <li><a href="http://samvera.github.io/actor_stack.html">Working with the Actor Stack</a></li>
             
             
             
@@ -448,61 +448,61 @@
                     
                     
                     
-                    <li><a href="http://localhost:4000/collection-overview.html">Overview</a></li>
+                    <li><a href="http://samvera.github.io/collection-overview.html">Overview</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/collection-types.html">Collection Types</a></li>
+                    <li><a href="http://samvera.github.io/collection-types.html">Collection Types</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/admin-sets-as-collections-faq.html">Admin Sets as Collections FAQ</a></li>
+                    <li><a href="http://samvera.github.io/admin-sets-as-collections-faq.html">Admin Sets as Collections FAQ</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/admin-set-participants.html">Admin Set Participants</a></li>
+                    <li><a href="http://samvera.github.io/admin-set-participants.html">Admin Set Participants</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/collection-type-participants.html">Collection Type Participants</a></li>
+                    <li><a href="http://samvera.github.io/collection-type-participants.html">Collection Type Participants</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/collection-sharing.html">Collection Sharing</a></li>
+                    <li><a href="http://samvera.github.io/collection-sharing.html">Collection Sharing</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/collection-nesting-faq.html">Collection Nesting FAQ</a></li>
+                    <li><a href="http://samvera.github.io/collection-nesting-faq.html">Collection Nesting FAQ</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/collection-discovery-faq.html">Collection Discovery FAQ</a></li>
+                    <li><a href="http://samvera.github.io/collection-discovery-faq.html">Collection Discovery FAQ</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/collection-metadata-faq.html">Collection Metadata FAQ</a></li>
+                    <li><a href="http://samvera.github.io/collection-metadata-faq.html">Collection Metadata FAQ</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/nested-indexing.html">Collection Indexing</a></li>
+                    <li><a href="http://samvera.github.io/nested-indexing.html">Collection Indexing</a></li>
                     
                     
                     
@@ -517,61 +517,61 @@
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-generate-work-type.html">Prereq: Generating a Work Type</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-generate-work-type.html">Prereq: Generating a Work Type</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-controlled-vocabulary.html">Prereq: Defining a Controlled Vocabulary</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-controlled-vocabulary.html">Prereq: Defining a Controlled Vocabulary</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/metadata_application_profile.html">Metadata Application Profile</a></li>
+                    <li><a href="http://samvera.github.io/metadata_application_profile.html">Metadata Application Profile</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-labels.html">Labels and Help Text</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-labels.html">Labels and Help Text</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-controller.html">Understanding the Controller</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-controller.html">Understanding the Controller</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-model.html">Defining Metadata in the Model</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-model.html">Defining Metadata in the Model</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-edit-form.html">Modifying the Edit Form</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-edit-form.html">Modifying the Edit Form</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-show-page.html">Modifying the Show Page</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-show-page.html">Modifying the Show Page</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-discovery.html">Configuring Discovery</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-discovery.html">Configuring Discovery</a></li>
                     
                     
                     
                     
                     
-                    <li><a href="http://localhost:4000/customize-metadata-other-customizations.html">Other Metadata Customizations</a></li>
+                    <li><a href="http://samvera.github.io/customize-metadata-other-customizations.html">Other Metadata Customizations</a></li>
                     
                     
                     
@@ -583,49 +583,49 @@
             
             
             
-            <li><a href="http://localhost:4000/building-searches.html">How Do I Build Searches?</a></li>
+            <li><a href="http://samvera.github.io/building-searches.html">How Do I Build Searches?</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/access-controls.html">Access Controls and Visibility</a></li>
+            <li><a href="http://samvera.github.io/access-controls.html">Access Controls and Visibility</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/email_notifications.html">Email Notifications</a></li>
+            <li><a href="http://samvera.github.io/email_notifications.html">Email Notifications</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/troubleshooting_riiif.html">RIIIF</a></li>
+            <li><a href="http://samvera.github.io/troubleshooting_riiif.html">RIIIF</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/external_binaries.html">External Binaries</a></li>
+            <li><a href="http://samvera.github.io/external_binaries.html">External Binaries</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/how-to-disable-notifications.html">How Do I Disable Hyrax 1 User Notifications?</a></li>
+            <li><a href="http://samvera.github.io/how-to-disable-notifications.html">How Do I Disable Hyrax 1 User Notifications?</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/workflow_and_mediated_deposit.html">Workflow and Mediated Deposit</a></li>
+            <li><a href="http://samvera.github.io/workflow_and_mediated_deposit.html">Workflow and Mediated Deposit</a></li>
             
             
             
@@ -640,21 +640,21 @@
             
             
             
-            <li><a href="http://localhost:4000/service-stack.html">Samvera Services Stack</a></li>
+            <li><a href="http://samvera.github.io/service-stack.html">Samvera Services Stack</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/campus-auth-integrating.html">Campus Authentication with Shibboleth</a></li>
+            <li><a href="http://samvera.github.io/campus-auth-integrating.html">Campus Authentication with Shibboleth</a></li>
             
             
             
             
             
             
-            <li><a href="http://localhost:4000/troubleshooting-production.html">Troubleshooting Production</a></li>
+            <li><a href="http://samvera.github.io/troubleshooting-production.html">Troubleshooting Production</a></li>
             
             
             
@@ -670,7 +670,7 @@
            -->
     </li>
     <li>
-      <a href="http://localhost:4000/glossary-2.1.html">Glossary</a>
+      <a href="http://samvera.github.io/glossary-2.1.html">Glossary</a>
     </li>
 </ul>
 
@@ -718,7 +718,7 @@ $('#toc').on('click', 'a', function() {
 
     
 
-  <!-- <link rel="stylesheet" href="http://localhost:4000/css/browse_pages.css"> -->
+  <!-- <link rel="stylesheet" href="http://samvera.github.io/css/browse_pages.css"> -->
 <link rel="stylesheet" href="/css/browse_pages.css">
 
 <div id="page_lists">
@@ -3609,7 +3609,7 @@ $('document').ready(function() {
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;2018 Samvera Community. All rights reserved. <br />
- Site last generated: Oct 2, 2018 <br />
+ Site last generated: Oct 4, 2018 <br />
 <a href="http://samvera.org/">samvera.org</a><br />
 <a href="https://wiki.duraspace.org/display/samvera/Samvera">Community Wiki</a></a><br />
 <p><img src="/images/company_logo.png" alt="Company logo"/></p>


### PR DESCRIPTION
This is to get around Github page not honoring the 'keep_page' directive in Jekyll config.

Normally, you could specify dynamically generated pages to the destination directory in 'keep_pages'
and those files won't get clobbered when the site is re-build, but Github Pages seems to clobber
them anyway.

So here we add a bit of logic to copy generated files form the destination directory to the source
directory, as html, so that Github will copy them over to the destination directory as-is.