### PR TITLE
Upgrade ffi and rubyzip to address security issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,12 @@ source "https://rubygems.org"
 # gem 'documentation-theme-jekyll', github: 'elrayle/documentation-theme-jekyll', branch: 'gh-pages'
 
 # gem 'github-pages', group: :jekyll_plugins
+gem 'ffi', '>= 1.9.24'
 gem 'github-pages' # plugins will not run if group: :jekyll_plugins is used
 gem 'html-proofer'
 gem 'rake'
 gem 'nokogiri', '>=1.8.2'
+gem 'rubyzip', '>= 1.2.2'
 
 group :development, :test do
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     execjs (2.7.0)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
+    ffi (1.9.25)
     forwardable-extended (2.6.0)
     gemoji (3.0.0)
     github-pages (142)
@@ -235,7 +235,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.4.25)
     sawyer (0.8.1)
@@ -262,6 +262,7 @@ PLATFORMS
 DEPENDENCIES
   capybara
   chromedriver-helper
+  ffi (>= 1.9.24)
   github-pages
   html-proofer
   launchy
@@ -270,7 +271,8 @@ DEPENDENCIES
   rack-jekyll
   rake
   rspec
+  rubyzip (>= 1.2.2)
   selenium-webdriver
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
References:
https://nvd.nist.gov/vuln/detail/CVE-2018-1000201
https://nvd.nist.gov/vuln/detail/CVE-2018-1000544