### PR TITLE
Change LDP product owner

### DIFF
--- a/pages/samvera/developer_community/git_structure/core_components.md
+++ b/pages/samvera/developer_community/git_structure/core_components.md
@@ -157,7 +157,7 @@ Please note that Hyrax is not considered a 'component' under the definition used
 
 **Code:** [ldp](https://github.com/samvera/ldp)
 
-**Product Owner:** [Carrick Rogers](https://github.com/carrickr)
+**Product Owner:** [Randall Floyd](https://github.com/randalldfloyd)
 
 **Vital Statistics:**
 


### PR DESCRIPTION
Randall accepted the product owner role for LDP on 10/31/2018 via the samvera-tech email list.