### PR TITLE
added links to Nurax/Hyku docker to getting_started

### DIFF
--- a/pages/samvera/1_new_start_here/getting-started.md
+++ b/pages/samvera/1_new_start_here/getting-started.md
@@ -9,6 +9,13 @@ toc: false
 folder: samvera/getting_started/
 ---
 
+### Tyre Kicking with Hyrax
+
+Hyku (multi-tenant Hyrax application) and Nurax (Hyrax instance for testing) both provide Docker scripts to help you get a development instance up and runing quickly:
+
+- [Running Nurax with Docker](https://github.com/curationexperts/nurax/blob/master/DOCKER.md)
+- [Running Hyku with Docker](https://github.com/samvera/hyku#with-docker)
+
 ### External Components
 
 - [ImageMagick](http://www.imagemagick.org/) with JPEG-2000 support


### PR DESCRIPTION
Trying to make it a bit easier for newbies by adding links to the docker scripts for Nurax and Hyku