### PR TITLE
Updates the CircleCI configuration to test against Ruby releases 2.6.3, 2.5.5, and 2.4.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,14 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.5.5
+        default: 2.6.3
       bundler_version:
         type: string
         default: 1.17.3
-      rails_version:
-        type: string
-        default: '5.2.2'
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
     environment:
-      RAILS_VERSION: << parameters.rails_version >>
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
     steps:
       - samvera/cached_checkout
@@ -34,7 +30,7 @@ jobs:
     parameters:
       ruby_version:
         type: string
-        default: 2.5.5
+        default: 2.6.3
       bundler_version:
         type: string
         default: 1.17.3
@@ -56,15 +52,26 @@ workflows:
   ci:
     jobs:
       - bundle:
-          ruby_version: "2.5.5"
-          rails_version: "5.1.7"
+          name: "bundle_ruby2-6"
+          ruby_version: "2.6.3"
       - test:
-          name: "ruby2-5-5"
+          name: "ruby2-6"
+          ruby_version: "2.6.3"
+          requires:
+            - bundle_ruby2-6
+      - bundle:
+          name: "bundle_ruby2-5"
+          ruby_version: "2.5.5"
+      - test:
+          name: "ruby2-5"
           ruby_version: "2.5.5"
           requires:
-            - bundle
+            - bundle_ruby2-5
+      - bundle:
+          name: "bundle_ruby2-4"
+          ruby_version: "2.4.6"
       - test:
-          name: "ruby2-6-2"
-          ruby_version: "2.6.2"
+          name: "ruby2-4"
+          ruby_version: "2.4.6"
           requires:
-            - bundle
+            - bundle_ruby2-4

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,12 @@ group :development, :test do
   gem "pry-byebug"
   gem 'rspec_junit_formatter'
 end
+
+if ENV['RAILS_VERSION']
+  if ENV['RAILS_VERSION'] == 'edge'
+    gem 'rails', github: 'rails/rails'
+    ENV['ENGINE_CART_RAILS_OPTIONS'] = '--edge --skip-turbolinks'
+  else
+    gem 'rails', ENV['RAILS_VERSION']
+  end
+end


### PR DESCRIPTION
Please note that this component does *not* require `rails` as a Gem dependency, and is locked to `activesupport` release 4.2.10 (due to upstream requirements for `github-pages` and `jekyll`).  Resolves #398 