### PR TITLE
Update CI references to CircleCI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,14 +133,14 @@ You should also add yourself to the `CONTRIBUTORS.md` file in the root of the pr
 We adopted [Github's Pull Request Review](https://help.github.com/articles/about-pull-request-reviews/) for our repositories.
 Common checks that may occur in our repositories:
 
-1. Travis CI - where our automated tests are running
-2. Hound CI - where we check for style violations
+1. [CircleCI](https://circleci.com/gh/samvera) - where our automated tests are running
+2. RuboCop/Bixby - where we check for style violations
 3. Approval Required - Github enforces at least one person approve a pull request. Also, all reviewers that have chimed in must approve.
 4. CodeClimate - is our code remaining healthy (at least according to static code analysis)
 
 If one or more of the required checks failed (or are incomplete), the code should not be merged (and the UI will not allow it). If all of the checks have passed, then anyone on the project (including the pull request submitter) may merge the code.
 
-*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (Travis CI is usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
+*Example: Carolyn submits a pull request, Justin reviews the pull request and approves. However, Justin is still waiting on other checks (CI tests are usually the culprit), so he does not merge the pull request. Eventually, all of the checks pass. At this point, Carolyn or anyone else may merge the pull request.*
 
 #### Things to Consider When Reviewing
 
@@ -157,7 +157,7 @@ This is your chance for a mentoring moment of another developer. Take time to gi
   * Do new or changed methods, modules, and classes have documentation?
   * Does the commit contain more than it should? Are two separate concerns being addressed in one commit?
   * Does the description of the new/changed specs match your understanding of what the spec is doing?
-  * Did the Travis tests complete successfully?
+  * Did the Continous Integration tests complete successfully?
 
 If you are uncertain, bring other contributors into the conversation by assigning them as a reviewer.
 

--- a/pages/samvera/developer_community/contributing_code/code.md
+++ b/pages/samvera/developer_community/contributing_code/code.md
@@ -26,7 +26,7 @@ We also recommend writing tests early and running them often, making small commi
 
 Many developers in the Samvera community practice [test-driven development](https://en.wikipedia.org/wiki/Test-driven_development), and you will notice as you begin submitting pull requests that the common code review process requires that you cover all code changes with tests; this is equally true of bugfixes, features, and refactoring changes.
 
-We tend to use RSpec as our testing tool of choice, with Capybara for feature tests, and our tests tend to conform to [community-driven testing guidelines](http://betterspecs.org/). All of our codebases on GitHub integrate with the Travis continuous integration service, which allows reviewers to see if changes made in pull requests have a passing test suite. We also tend to use Coveralls to determine whether the proposed changes have increased or decreased overall code coverage.
+We tend to use RSpec as our testing tool of choice, with Capybara for feature tests, and our tests tend to conform to [community-driven testing guidelines](http://betterspecs.org/). All of our codebases on GitHub integrate with the CircleCI or Travis continuous integration services, which allows reviewers to see if changes made in pull requests have a passing test suite. We also tend to use Coveralls to determine whether the proposed changes have increased or decreased overall code coverage.
 
 ## Style guidelines
 

--- a/pages/samvera/developer_community/contributing_code/coding_style.md
+++ b/pages/samvera/developer_community/contributing_code/coding_style.md
@@ -8,7 +8,7 @@ sidebar: home_sidebar
 
 # Importance of Consistent Coding Styles
 
-Coding styles are controlled by RuboCop which performs a number of style related checks on the code.  The code may run fine and pass tests while not being style compliant, but compliance with the configured style makes code easier to read and maintain.  Travis CI for Hyrax and many other Samvera gems is configured to fail if RuboCop detects errors.  It is recommneded that you configure Travis CI to fail for RuboCop errors in your Samvera based apps.
+Coding styles are controlled by RuboCop which performs a number of style related checks on the code.  The code may run fine and pass tests while not being style compliant, but compliance with the configured style makes code easier to read and maintain.  The continuous integration (CI) service for Hyrax and many other Samvera gems is configured to fail if RuboCop detects errors.  It is recommneded that you configure CI to fail for RuboCop errors in your Samvera based apps.
 
 # What is RuboCop
 

--- a/pages/samvera/developer_community/contributing_code/how-to-pr.md
+++ b/pages/samvera/developer_community/contributing_code/how-to-pr.md
@@ -20,7 +20,7 @@ Before pushing any new commits to your pull request, you may wish to do the foll
   * If any of your PR changes depend on brand new gems, then you will need to ensure your Gemfile.lock gets updated in the codebase. This file controls the version of all gems (including Hyrax) that are currently in use.
   * Just run bundle update AND commit the changes made to your local Gemfile.lock
 
-        NOTE: if you forget to update the Gemfile.lock file in your PR, then Travis CI will not pick up the latest versions of Hyrax, and therefore may throw unexpected errors.
+        NOTE: if you forget to update the Gemfile.lock file in your PR, then the CI service will not pick up the latest versions of Hyrax, and therefore may throw unexpected errors.
 
     Once your PR is ready for review, remove the [WIP] prefix from your PRs name and ping the development team (on Slack or GitHub).
 

--- a/pages/samvera/developer_community/contributing_code/pr_checklist.md
+++ b/pages/samvera/developer_community/contributing_code/pr_checklist.md
@@ -20,8 +20,7 @@ Checklist to use when creating and reviewing a PR.
   - [ ] Feature tests:  There are tests that cover the functionality as it is used by end users in the UI.
   - [ ] Test efficiency: Tests use factorybot `build` instead of `create` where ever possible.  This is especially important for repository objects that cause the object to be created in Fedora.
   - [ ] Test coverage: Test coverage stayed the same or rose.  Review coveralls report for the PR.
-  - [ ] Travis completes without error for continuous-integration/travis-ci/push.
-  - [ ] Travis completes without error for continuous-integration/travis-ci/pr.
+  - [ ] The continous integration (CI) service completes without error.
 - Backward compatibility
   - [ ] Public API: Public method signatures are not changed when going into a bug release or minor release.  These are ok for a major release, but should be an intentional change that is deemed necessary.
   - [ ] Public API: Requires unit tests exist that ensure correct behavior of new classes/modules/methods

--- a/pages/samvera/developer_community/contributing_code/review.md
+++ b/pages/samvera/developer_community/contributing_code/review.md
@@ -44,7 +44,7 @@ Pull requests are evaluated in many different ways; fortunately, we have tools t
 review so that human review can focus on overall code quality and maintainability. For instance, we
 use:
 
-* TravisCI, to ensure the test suite is passing
+* A continous integration (CI) service, to ensure the test suite is passing (typically CircleCI or Travis)
 * Rubocop, to be consistent w/ a baseline of Ruby style conventions
 * Coveralls, to ensure code changes are covered by test changes
 * Hound, to be consistent w/ Javascript and CSS style conventions
@@ -65,7 +65,7 @@ The key things to focus on are:
 As a reviewer, it's also your responsibility to make sure:
 
 * Does the submitter have a signed CLA [on file](https://wiki.duraspace.org/display/samvera/CLA+submission+list)?
-* Did the Travis tests complete successfully?
+* Did the CI tests complete successfully?
 * Is there a significant drop in code coverage?
 * Do all new or changed methods, modules, and classes have comments?
 

--- a/pages/samvera/developer_community/git_structure/core_components.md
+++ b/pages/samvera/developer_community/git_structure/core_components.md
@@ -210,7 +210,7 @@ Please note that Hyrax is not considered a 'component' under the definition used
 **Vital Statistics:**
 
 [![Gem Version](https://badge.fury.io/rb/hydra-works.svg)](https://badge.fury.io/rb/hydra-works)
-[![Build Status](https://travis-ci.org/samvera/hydra-works.svg?branch=master)](https://travis-ci.org/samvera/hydra-works)
+[![Build Status](https://circleci.com/gh/samvera/hydra-works.svg?style=svg)](https://circleci.com/gh/samvera/hydra-works)
 [![Coverage Status](https://coveralls.io/repos/github/samvera/hydra-works/badge.svg?branch=master)](https://coveralls.io/github/samvera/hydra-works?branch=master)
 
 ### hydra-file_characterization

--- a/pages/samvera/developer_community/git_structure/samvera_labs.md
+++ b/pages/samvera/developer_community/git_structure/samvera_labs.md
@@ -30,7 +30,7 @@ requirements must be met:
 
   1. Good unit test coverage measured by community (e.g. 100% or 75% of what’s important)
 
-  1. uses CI (Preferably Travis-CI, unless there is a compelling reason to do something else)
+  1. uses CI (Preferably CircleCI, unless there is a compelling reason to do something else)
 
   1. uses Coverage tool (coveralls or simplecov)
 


### PR DESCRIPTION
Generalize references to CI where possible or switch to CircleCI where an explicit service is referenced.