### PR TITLE
Update links to wiki following migrations 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ All code contributors must have an Individual Contributor License Agreement
 an institution, the institution must have a Corporate Contributor License
 Agreement (cCLA) on file.
 
-https://wiki.duraspace.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
+https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211651/Samvera+Community+Intellectual+Property+Licensing+and+Ownership
 
 You should also add yourself to the `CONTRIBUTORS.md` file in the root of the project.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,10 +77,10 @@ further details.
   * Test functionality with RSpec; Test features / UI with Capybara.
 * Run _all_ the tests to assure nothing else was accidentally broken.
 
-NOTE: This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) 
-and [language recommendations](#language).  
-Please ***do not*** create a branch called `master` for this repository or as part of 
-your pull request; the branch will either need to be removed or renamed before it can 
+NOTE: This repository follows the [Samvera Community Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct)
+and [language recommendations](#language).
+Please ***do not*** create a branch called `master` for this repository or as part of
+your pull request; the branch will either need to be removed or renamed before it can
 be considered for inclusion in the code base and history of this repository.
 
 ### Documenting Code

--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ organization_link: http://samvera.org/
 organization_link_name: samvera.org
 # this appears in the footer
 
-community_link: https://wiki.duraspace.org/display/samvera/Samvera
+community_link: https://samvera.atlassian.net/wiki/spaces/samvera/overview
 community_link_name: Community Wiki
 # this appears in the footer
 

--- a/browse_pages.html
+++ b/browse_pages.html
@@ -3526,7 +3526,7 @@ $('document').ready(function() {
                &copy;2018 Samvera Community. All rights reserved. <br />
  Site last generated: Nov 30, 2018 <br />
 <a href="http://samvera.org/">samvera.org</a><br />
-<a href="https://wiki.duraspace.org/display/samvera/Samvera">Community Wiki</a></a><br />
+<a href="https://samvera.atlassian.net/wiki/spaces/samvera/overview">Community Wiki</a></a><br />
 <p><img src="/images/company_logo.png" alt="Company logo"/></p>
                 </div>
             </div>

--- a/pages/samvera/1_new_start_here/formalities.md
+++ b/pages/samvera/1_new_start_here/formalities.md
@@ -1,7 +1,7 @@
 ---
 title: Formalities
 permalink: formalities.html
-last_updated: March 30, 2017
+last_updated: February 2, 2022
 keywords: ["Formalities", "CLA", "License Agreements", "Contributor License Agreement"]
 tags: getting_started
 summary: "What is a CLA and why do I need one? How do I join the community as a contributor?"
@@ -15,7 +15,7 @@ Samvera uses an Apache-based Contributor License Agreement to ensure that code c
 
 In short, to contribute any code to any Samvera codebase, we will need to have two CLAs on file for you: one that you sign yourself, and one that someone with signatory authority at your institution signs. To contribute non-code assets, such as documentation, you are not required to sign any CLAs; we merely ask that you make your contributions available under a Creative Commons license.
 
-See [Samvera Community Intellectual Property Licensing and Ownership](https://wiki.duraspace.org/display/samvera/Samvera+Community+Intellectual+Property+Licensing+and+Ownership) for more details.
+See [Samvera Community Intellectual Property Licensing and Ownership](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211651/Samvera+Community+Intellectual+Property+Licensing+and+Ownership) for more details.
 
 ## Membership in GitHub organizations and repositories
 

--- a/pages/samvera/1_new_start_here/get-help.md
+++ b/pages/samvera/1_new_start_here/get-help.md
@@ -1,7 +1,7 @@
 ---
 title: "Help Resources"
 permalink: get-help.html
-last_updated:
+last_updated: February 2, 2022
 keywords: ["Contact", "Community", "Help"]
 toc: true
 tags: [getting_started]
@@ -76,7 +76,7 @@ A tutorial can be found [here](https://samvera.slack.com/getting-started).  Slac
   Wednesdays at 9:00 AM Pacific Time, noon Eastern Time
   Check out this helpful [time zone](http://www.timeanddate.com/worldclock/fixedtime.html?month=12&day=6&year=2010&hour=8&min=0&sec=0&p1=224) translation
 
-  Connect via [Zoom](https://psu.zoom.us/j/613720745), which will launch the Zoom client. Instructions to connect by telephone are included at the top of [the agenda for each call](https://wiki.duraspace.org/display/samvera/Notes+from+Meetings+and+Calls).  
+  Connect via [Zoom](https://psu.zoom.us/j/613720745), which will launch the Zoom client. Instructions to connect by telephone are included at the top of [the agenda for each call](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211059/Notes+from+Tech+Meetings+and+Calls).
 
 - **Monthly Partner Call**
 

--- a/pages/samvera/1_new_start_here/get-help.md
+++ b/pages/samvera/1_new_start_here/get-help.md
@@ -101,9 +101,9 @@ A tutorial can be found [here](https://samvera.slack.com/getting-started).  Slac
 
   For more information on how to start using irc, check out the instructions on the [code4lib](http://code4lib.org/irc) site.
 
-## DuraSpace Wiki
+## Samvera Wiki
 
-The [DuraSpace Wiki](Samvera Wiki (this site) http://wiki.duraspace.org/display/samvera) has a wealth of information, and is the place where working groups are formed and track their progress, where the technical calls record their agendas and meetings notes. You need an account for the DuraSpace Wiki so that you can contribute to Samvera's pages. If you do not have one already, please request an account by sending an email to sysadmin@duraspace.org.
+The [Samvera Wiki](https://samvera.atlassian.net/wiki/spaces/samvera/overview) has a wealth of information, and is the place where working groups are formed and track their progress, where the technical calls record their agendas and meetings notes. You need an account for the Samvera Wiki so that you can contribute to Samvera's pages. If you do not have one already, please request an account by sending an email to heather@samvera.org.
 
 ## Samvera Connect, Partner & Steering Group Meetings
 

--- a/pages/samvera/1_new_start_here/introduction.md
+++ b/pages/samvera/1_new_start_here/introduction.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction to Samvera
 permalink: introduction.html
-last_updated: March 30, 2017
+last_updated: February 2, 2022
 keywords: ["Samvera", "Orientation", "Introduction"]
 sidebar: home_sidebar
 folder: samvera/getting_started/
@@ -15,7 +15,7 @@ We build repository systems to manage digital content for the long-term. This co
 
 ## Samvera is a framework
 
-![Architecture Diagram](https://wiki.duraspace.org/download/attachments/87460044/hydra_9_architecture_2016.png?version=1&modificationDate=1497776440777&api=v2)
+![Architecture Diagram](https://samvera.atlassian.net/wiki/download/thumbnails/405211335/hydra_9_architecture_2016.png?version=1&modificationDate=1497758440777&api=v2)
 
 Samvera began its life in 2008 as a framework: a shared set of patterns and tools, primarily in the
 form of Ruby code, for building repository applications atop the [Fedora Commons Repository](http://fedorarepository.org/)
@@ -23,7 +23,7 @@ and the [Apache Solr](http://lucene.apache.org/solr/) index.
 
 ## Samvera is a community
 
-![HydraConnect 2015 Group Photo](https://wiki.duraspace.org/download/attachments/87459342/HydraConnect2015-pano.jpg?version=1&modificationDate=1497702812221&api=v2)
+![HydraConnect 2015 Group Photo](https://samvera.atlassian.net/wiki/download/attachments/405210633/HydraConnect2015-pano.jpg?api=v2)
 
 Samvera is a growing and vibrant community of people, representing a diverse array of skill sets, backgrounds, and employers. None of us is paid directly by Samvera, and so we're also a community of volunteers; things happen in the Samvera community because individuals step forward to make advancements.
 

--- a/pages/samvera/1_new_start_here/our_technology_stack.md
+++ b/pages/samvera/1_new_start_here/our_technology_stack.md
@@ -3,13 +3,13 @@ title: "Technology Stack"
 permalink: our_technology_stack.html
 keywords: [ "Hyrax", "Front End", "Blacklight", "Rails", "Hydra Editor", "Search",
             "Persistence", "Solr", "Fedora", "Middleware", "Hydra Head", "Ldp", "Plugins" ]
-last_updated:
+last_updated: February 2, 2022
 tags: [getting_started]
 summary: "An introduction to the technologies used in Samvera"
 folder: samvera/getting_started/
 ---
 
-![Architecture Diagram](https://wiki.duraspace.org/download/attachments/87460044/hydra_9_architecture_2016.png?version=1&modificationDate=1497776440777&api=v2)
+![Architecture Diagram](https://samvera.atlassian.net/wiki/download/thumbnails/405211335/hydra_9_architecture_2016.png?version=1&modificationDate=1497758440777&cacheVersion=1&api=v2)
 
 ## Hyrax
 

--- a/pages/samvera/developer_community/communication.md
+++ b/pages/samvera/developer_community/communication.md
@@ -1,7 +1,7 @@
 ---
 title: Communication
 permalink: communication.html
-last_updated: March 30, 2017
+last_updated: February 2, 2022
 tags: [getting_started, community]
 summary: "Community Channels of Communication"
 folder: samvera/developer_community/
@@ -33,7 +33,7 @@ Slack has become the primary mode of synchronous communication in the Samvera co
 
 ## Wiki
 
-* DuraSpace wiki: https://samvera.atlassian.net/wiki/spaces/samvera/overview for general project
+* Samvera wiki: https://samvera.atlassian.net/wiki/spaces/samvera/overview for general project
   documentation, meeting notes, and working group pages
   * To request an account, please email [sysadmin@duraspace.org](mailto:heather@samvera.org)
 * GitHub codebase-specific wikis for technical documentation and tutorials: e.g.,

--- a/pages/samvera/developer_community/communication.md
+++ b/pages/samvera/developer_community/communication.md
@@ -10,7 +10,7 @@ folder: samvera/developer_community/
 
 This page details the communication channels used by developers in the Samvera community.  For more
 information on broader community communication, please see the Samvera wiki
-[Get in touch!](https://wiki.duraspace.org/pages/viewpage.action?pageId=87460391) page.
+[Get Started in the Samvera Community](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211682/Getting+Started+in+the+Samvera+Community) page.
 
 ## Regular Calls
 

--- a/pages/samvera/developer_community/communication.md
+++ b/pages/samvera/developer_community/communication.md
@@ -35,7 +35,7 @@ Slack has become the primary mode of synchronous communication in the Samvera co
 
 * Samvera wiki: https://samvera.atlassian.net/wiki/spaces/samvera/overview for general project
   documentation, meeting notes, and working group pages
-  * To request an account, please email [sysadmin@duraspace.org](mailto:heather@samvera.org)
+  * To request an account, please email [heather@samvera.org](mailto:heather@samvera.org)
 * GitHub codebase-specific wikis for technical documentation and tutorials: e.g.,
   * https://github.com/samvera/hydra-head/wiki
   * https://github.com/samvera/sufia/wiki

--- a/pages/samvera/developer_community/contributing_code/review.md
+++ b/pages/samvera/developer_community/contributing_code/review.md
@@ -2,7 +2,7 @@
 title: Code Review
 permalink: review.html
 keywords: ["Code", "Review", "PR", "Pull Request"]
-last_updated: March 30, 2017
+last_updated: February 2, 2022
 folder: samvera/developer_community/contributing_code/
 tags: [getting_started, community]
 summary: "Procedure for adding code to a community repository"
@@ -64,7 +64,7 @@ The key things to focus on are:
 
 As a reviewer, it's also your responsibility to make sure:
 
-* Does the submitter have a signed CLA [on file](https://wiki.duraspace.org/display/samvera/CLA+submission+list)?
+* Does the submitter have a signed CLA [on file](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211653/CLA+collection+process)?
 * Did the CI tests complete successfully?
 * Is there a significant drop in code coverage?
 * Do all new or changed methods, modules, and classes have comments?

--- a/pages/samvera/developer_community/contributing_code/review.md
+++ b/pages/samvera/developer_community/contributing_code/review.md
@@ -64,7 +64,7 @@ The key things to focus on are:
 
 As a reviewer, it's also your responsibility to make sure:
 
-* Does the submitter have a signed CLA [on file](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211653/CLA+collection+process)?
+* Does the submitter have a signed CLA? (Indicated by a `cla-signed` label in github.)
 * Did the CI tests complete successfully?
 * Is there a significant drop in code coverage?
 * Do all new or changed methods, modules, and classes have comments?

--- a/pages/samvera/developer_community/git_structure/samvera_labs.md
+++ b/pages/samvera/developer_community/git_structure/samvera_labs.md
@@ -2,7 +2,7 @@
 title: Samvera Labs
 permalink: samvera_labs.html
 keywords: ["Labs", "Experiments", "Starting a Project", "Development"]
-last_updated: February 26, 2018
+last_updated: February 2, 2022
 folder: samvera/developer_community/git_structure/
 sidebar: samvera_sidebar
 toc: true
@@ -36,7 +36,7 @@ requirements must be met:
 
   1. Show compatibility with current Rails versions and other dependencies, when was it last tested; note compatibility with prior versions when available. Compatibility can be specified in the gemspec(s) or verified via CI matrix.
 
-  1. [Hierarchy of promises](https://wiki.duraspace.org/display/samvera/Hydra+Stack+-+The+Hierarchy+of+Promises) asserted in clearly defined acceptance tests
+  1. [Hierarchy of promises](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211336/Hydra+Stack+-+The+Hierarchy+of+Promises) asserted in clearly defined acceptance tests
 
 ### Documentation Requirements
 

--- a/pages/samvera/developer_community/releases/release_process.md
+++ b/pages/samvera/developer_community/releases/release_process.md
@@ -2,12 +2,12 @@
 title: Hyrax Testing and Release Process
 permalink: release_process.html
 keywords: ['Release', 'Nurax', "Testing"]
-last_updated: February 5, 2018
+last_updated: February 5, 2022
 toc: true
 folder: samvera/developer_community/releases/
 ---
 
-The [Repository Managers Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group) will work with the Hyrax PO to test and document features for Hyrax releases. For each release cycle, there will be at least one designated QA Specialist from the [Hyrax Working Group](https://wiki.duraspace.org/display/samvera/Hyrax+Working+Group) or the Repo-Managers to facilitate the process. [Instructions for conducting release testing can be found here](/release_testing.html) (in progress).
+The [Repository Managers Interest Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212548/Samvera+Repository+Management+Interest+Group) will work with the Hyrax PO to test and document features for Hyrax releases. For each release cycle, there will be at least one designated QA Specialist from the [Hyrax Working Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/496632295/Hyrax+Maintenance+Working+Group) or the Repo-Managers to facilitate the process. [Instructions for conducting release testing can be found here](/release_testing.html) (in progress).
 
 For each cycle the Release Testing facilitator will:
 
@@ -68,7 +68,7 @@ This testing process complements test coverage and regression testing in the cod
 
 - Follows the Major release process on a much more compressed timeline.
 
-- Upgrade demo site, retaining data. In the occasion that data needs to be wiped for whatever reason, this is fine. Mostly we want to test that data and users migrate smoothly.  
+- Upgrade demo site, retaining data. In the occasion that data needs to be wiped for whatever reason, this is fine. Mostly we want to test that data and users migrate smoothly.
 
 
 ### Hyrax Shared Testing Tools:
@@ -88,12 +88,12 @@ This testing process complements test coverage and regression testing in the cod
 **Hyrax Feature Guide:** describes features, set up and concepts for Hyrax repositories
 
  - [http://samvera.github.io/](http://samvera.github.io/) (select **Feature Guide** in side navigation)
- - Maintained and updated by the [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group). Ask Chris Diaz for more information.
+ - Maintained and updated by the [Repository Management Interest Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212548/Samvera+Repository+Management+Interest+Group). Ask Chris Diaz for more information.
 
 **Hyrax test tracking document:** google doc that helps us track what is tested (including browsers and accessibility) for each release.
 
 -  This will be shared on the #nurax slack for each release. Contact Julie Rudder for help.
-- Maintained and updated by the [Repository Management Interest Group](https://wiki.duraspace.org/display/samvera/Repository+Management+Interest+Group)
+- Maintained and updated by the [Repository Management Interest Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212548/Samvera+Repository+Management+Interest+Group)
 
 
 **Testing list will include the following:**

--- a/pages/samvera/developer_community/releases/release_testing.md
+++ b/pages/samvera/developer_community/releases/release_testing.md
@@ -1,13 +1,13 @@
 ---
 title: How to Coordinate Testing for a Release
 keywords: ['Testing', 'Release', 'Community']
-last_updated: March 30, 2017
+last_updated: February 2, 2022
 sidebar: samvera_sidebar
 permalink: release_testing.html
 folder: samvera/developer_community/releases/
 ---
 
-Each release will have a release testing coordinator, usually the QA specialist from the [Hyrax Working Group](https://wiki.duraspace.org/display/samvera/Hyrax+Working+Group). This person can vary from release to release. They will work closely with the Hyrax Tech Lead and Product Owner. Follow the newly-defined process outlined in [Hyrax Testing and Release Process](/release_process.html). As this is a new process, you may find that some sections need adjustment or more detail.
+Each release will have a release testing coordinator, usually the QA specialist from the [Hyrax Working Group](https://samvera.atlassian.net/wiki/spaces/samvera/pages/496632295/Hyrax+Maintenance+Working+Group). This person can vary from release to release. They will work closely with the Hyrax Tech Lead and Product Owner. Follow the newly-defined process outlined in [Hyrax Testing and Release Process](/release_process.html). As this is a new process, you may find that some sections need adjustment or more detail.
 
 ### PR testing:
 


### PR DESCRIPTION
This site had a number of older links to either the DuraSpace or Lyrasis wikis, and this PR attempts to update them. 

* Questions are indicated by `[?]` in the commit message. (These represent things that are less clear to me).
* I have broken this out into individual commits in case there are things to discuss. Happy to rebase as a precondition of merging. 