### PR TITLE
Ensuring that the Jekyll site can be built for Ruby 3.2 releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
         type: string
       bundler_version:
         type: string
-        default: 2.3.11
+        default: 2.3.26
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
     environment:
-      WAIT_FOR_JEKYLL: 10
+      WAIT_FOR_JEKYLL: 1
       NOKOGIRI_USE_SYSTEM_LIBRARIES: true
     steps:
       - samvera/cached_checkout
@@ -27,6 +27,10 @@ jobs:
               echo "$(git branch --all --list master */master)"
             fi
             [[ -z "$(git branch --all --list master */master)" ]]
+      - run:
+          name: Ensure that libxslt is installed for the nokogiri gem
+          command: |
+            sudo apt-get update && sudo apt-get install -y libxslt1.1 libxslt1-dev pkg-config
       - samvera/bundle:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>
@@ -42,17 +46,15 @@ workflows:
   ci:
     jobs:
       - bundle_and_test:
+          name: ruby3-2
+          ruby_version: 3.2.2
+          bundler_version: 2.3.26
+      - bundle_and_test:
           name: ruby3-1
-          ruby_version: 3.1.1
+          ruby_version: 3.1.4
       - bundle_and_test:
           name: ruby3-0
-          ruby_version: 3.0.3
-      - bundle_and_test:
-          name: ruby2-7
-          ruby_version: 2.7.5
-      - bundle_and_test:
-          name: ruby2-6
-          ruby_version: 2.6.9
+          ruby_version: 3.0.6
 
   nightly:
     triggers:
@@ -64,14 +66,12 @@ workflows:
                 - main
     jobs:
       - bundle_and_test:
+          name: ruby3-2
+          ruby_version: 3.2.2
+          bundler_version: 2.3.26
+      - bundle_and_test:
           name: ruby3-1
-          ruby_version: 3.1.1
+          ruby_version: 3.1.4
       - bundle_and_test:
           name: ruby3-0
-          ruby_version: 3.0.3
-      - bundle_and_test:
-          name: ruby2-7
-          ruby_version: 2.7.5
-      - bundle_and_test:
-          name: ruby2-6
-          ruby_version: 2.6.9
+          ruby_version: 3.0.6

--- a/Gemfile
+++ b/Gemfile
@@ -1,27 +1,24 @@
 source "https://rubygems.org"
 
-# gem 'wdm'
-
-# gem 'documentation-theme-jekyll', github: 'elrayle/documentation-theme-jekyll', branch: 'gh-pages'
-
-# gem 'github-pages', group: :jekyll_plugins
 gem 'ffi', '>= 1.9.24'
 gem 'github-pages' # plugins will not run if group: :jekyll_plugins is used
 gem 'html-proofer'
-gem "jekyll", ">= 3.6.3"
+gem "jekyll", ">= 3.6"
+# Please see https://github.com/jekyll/jekyll/issues/9231#issuecomment-1379146408
+gem "liquid", ">= 4.0.4"
+gem 'nokogiri', '>= 1.12'
 gem 'rake'
-gem 'nokogiri', '>=1.8.2'
 gem 'rubyzip', '>= 1.2.2'
 
 group :development, :test do
+  gem "capybara"
+  gem "chromedriver-helper"
+  gem 'launchy'
+  gem "pry-byebug"
+  gem "rack-jekyll"
+  gem 'rspec_junit_formatter'
   gem "rspec"
   gem "selenium-webdriver"
-  gem "chromedriver-helper"
-  gem "capybara"
-  gem 'launchy'
-  gem "rack-jekyll"
-  gem "pry-byebug"
-  gem 'rspec_junit_formatter'
 end
 
 if ENV['RAILS_VERSION']

--- a/_config.yml
+++ b/_config.yml
@@ -86,16 +86,6 @@ defaults:
   -
     scope:
       path: ""
-      type: "tooltips"
-    values:
-      layout: "page"
-      comments: true
-      search: true
-      tooltip: true
-
-  -
-    scope:
-      path: ""
       type: "posts"
     values:
       layout: "post"

--- a/_tooltips/baseball.html
+++ b/_tooltips/baseball.html
@@ -1,6 +1,0 @@
----
-doc_id: baseball
-product: mydoc
----
-
-{{site.data.definitions.baseball}}

--- a/_tooltips/basketball.html
+++ b/_tooltips/basketball.html
@@ -1,6 +1,0 @@
----
-doc_id: basketball
-product: mydoc
----
-
-{{site.data.definitions.basketball}}

--- a/_tooltips/football.html
+++ b/_tooltips/football.html
@@ -1,6 +1,0 @@
----
-doc_id: football
-product: mydoc
----
-
-{{site.data.definitions.football}}

--- a/_tooltips/soccer.html
+++ b/_tooltips/soccer.html
@@ -1,6 +1,0 @@
----
-doc_id: soccer
-product: mydoc
----
-
-{{site.data.definitions.soccer}}

--- a/pages/samvera/1_new_start_here/formalities.md
+++ b/pages/samvera/1_new_start_here/formalities.md
@@ -2,7 +2,7 @@
 title: Formalities
 permalink: formalities.html
 last_updated: February 2, 2022
-keywords: ["Formalities", "Contributor"
+keywords: ["Formalities", "Contributor"]
 tags: getting_started
 summary: "Membership in GitHub organizations and repositories"
 folder: samvera/getting_started/

--- a/spec/homepage_spec.rb
+++ b/spec/homepage_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe "homepage", type: :feature, js: true do
   it "is accessible" do
     visit '/'


### PR DESCRIPTION
Deprecates #464 